### PR TITLE
style: 기본 버튼 공통 컴포넌트 구현

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,18 @@ const preview: Preview = {
 				date: /Date$/i,
 			},
 		},
+		backgrounds: {
+			values: [
+				{
+					name: "default",
+					value: "#1C1C22",
+				},
+				{
+					name: "white",
+					value: "white",
+				},
+			],
+		},
 	},
 };
 

--- a/src/components/common/button/BasicButton.tsx
+++ b/src/components/common/button/BasicButton.tsx
@@ -1,0 +1,54 @@
+import { cva, VariantProps } from "class-variance-authority";
+import { ButtonHTMLAttributes, ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> &
+	VariantProps<typeof buttonVariants> & {
+		label: string;
+		className?: string;
+	};
+
+const buttonVariants = cva(
+	"w-full rounded-[0.8rem] py-[1.3rem] text-[1.6rem] font-semibold disabled:text-gray-200 md:py-[1.55rem] md:text-[1.6rem] lg:py-[1.9rem] lg:text-[1.8rem]",
+	{
+		variants: {
+			variant: {
+				primary: "bg-main-gradient text-white disabled:bg-[#353542]",
+				secondary:
+					"text-main-gradient outline outline-main_blue disabled:outline-[#353542]",
+				tertiary:
+					"text-gray-100 outline outline-gray-100 disabled:outline-[#353542]",
+			},
+		},
+		defaultVariants: {
+			variant: "primary",
+		},
+	},
+);
+
+export default function BasicButton({
+	label,
+	variant = "primary",
+	className,
+	disabled,
+	...props
+}: Props) {
+	return (
+		<button
+			className={twMerge(
+				buttonVariants({ variant }),
+				className,
+				disabled && "bg-none",
+			)}
+			style={
+				variant === "secondary" && disabled
+					? { WebkitTextFillColor: "initial" }
+					: {}
+			}
+			disabled={disabled}
+			{...props}
+		>
+			{label}
+		</button>
+	);
+}

--- a/src/components/common/button/BasicButton.tsx
+++ b/src/components/common/button/BasicButton.tsx
@@ -1,5 +1,6 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ButtonHTMLAttributes, ReactNode } from "react";
+import clsx from "clsx";
+import { ButtonHTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> &
@@ -15,8 +16,7 @@ const buttonVariants = cva(
 			variant: {
 				primary:
 					"bg-main-gradient text-white disabled:bg-[#353542] disabled:bg-none",
-				secondary:
-					"text-main-gradient outline outline-main_blue disabled:outline-[#353542]",
+				secondary: "outline outline-main_blue disabled:outline-[#353542]",
 				tertiary:
 					"text-gray-100 outline outline-gray-100 disabled:outline-[#353542]",
 			},
@@ -37,15 +37,16 @@ export default function BasicButton({
 	return (
 		<button
 			className={twMerge(buttonVariants({ variant }), className)}
-			style={
-				variant === "secondary" && disabled
-					? { WebkitTextFillColor: "initial" }
-					: {}
-			}
 			disabled={disabled}
 			{...props}
 		>
-			{label}
+			<span
+				className={clsx(
+					variant === "secondary" && !disabled && "text-main-gradient",
+				)}
+			>
+				{label}
+			</span>
 		</button>
 	);
 }

--- a/src/components/common/button/BasicButton.tsx
+++ b/src/components/common/button/BasicButton.tsx
@@ -13,7 +13,8 @@ const buttonVariants = cva(
 	{
 		variants: {
 			variant: {
-				primary: "bg-main-gradient text-white disabled:bg-[#353542]",
+				primary:
+					"bg-main-gradient text-white disabled:bg-[#353542] disabled:bg-none",
 				secondary:
 					"text-main-gradient outline outline-main_blue disabled:outline-[#353542]",
 				tertiary:
@@ -35,11 +36,7 @@ export default function BasicButton({
 }: Props) {
 	return (
 		<button
-			className={twMerge(
-				buttonVariants({ variant }),
-				className,
-				disabled && "bg-none",
-			)}
+			className={twMerge(buttonVariants({ variant }), className)}
 			style={
 				variant === "secondary" && disabled
 					? { WebkitTextFillColor: "initial" }

--- a/src/stories/BasicButton.stories.ts
+++ b/src/stories/BasicButton.stories.ts
@@ -4,7 +4,7 @@ import { userEvent, within } from "@storybook/test";
 import BasicButton from "../components/common/button/BasicButton";
 
 const meta = {
-	title: "Component/BasicButton",
+	title: "Components/Common/BasicButton",
 	component: BasicButton,
 	tags: ["autodocs"],
 	args: {

--- a/src/stories/BasicButton.stories.ts
+++ b/src/stories/BasicButton.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 
 import BasicButton from "../components/common/button/BasicButton";

--- a/src/stories/BasicButton.stories.ts
+++ b/src/stories/BasicButton.stories.ts
@@ -1,0 +1,50 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+
+import BasicButton from "../components/common/button/BasicButton";
+
+const meta = {
+	title: "Component/BasicButton",
+	component: BasicButton,
+	tags: ["autodocs"],
+	args: {
+		label: "가입하기",
+	},
+} satisfies Meta<typeof BasicButton>;
+
+export default meta;
+
+export const Primary: StoryObj<typeof BasicButton> = {
+	args: {
+		variant: "primary",
+	},
+};
+
+export const Secondary: StoryObj<typeof BasicButton> = {
+	args: {
+		variant: "secondary",
+	},
+};
+
+export const Tertiary: StoryObj<typeof BasicButton> = {
+	args: {
+		variant: "tertiary",
+	},
+};
+
+const handleClick = () => {
+	alert("클릭");
+};
+
+export const ClickBasicButton = {
+	args: {
+		variant: "secondary",
+		onClick: handleClick,
+		disabled: true,
+	},
+	play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		await userEvent.click(button);
+	},
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,7 +24,6 @@ html {
 @layer utilities {
 	.text-main-gradient {
 		@apply bg-main-gradient bg-clip-text text-transparent;
-		-webkit-text-fill-color: transparent;
 	}
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,9 +16,16 @@
 	}
 }
 
-body {
+html {
 	font-size: 62.5%;
 	font-family: "Pretendard";
+}
+
+@layer utilities {
+	.text-main-gradient {
+		@apply bg-main-gradient bg-clip-text text-transparent;
+		-webkit-text-fill-color: transparent;
+	}
 }
 
 @font-face {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,10 +22,6 @@ const config: Config = {
 					100: "#9FA6B2",
 					200: "#6E6E82",
 				},
-				main_gradation: {
-					start: "#5097FA",
-					end: "#5363FF",
-				},
 				main_blue: "#5097FA",
 				main_indigo: "#5363FF",
 				yellow: "#FFC83C",
@@ -33,6 +29,9 @@ const config: Config = {
 				pink: "#FF2F9F",
 				red: "#FF0000",
 			},
+			backgroundImage: ({ theme }) => ({
+				"main-gradient": `linear-gradient(to right, ${theme("colors.main_blue")}, ${theme("colors.main_indigo")})`,
+			}),
 		},
 	},
 	plugins: [],


### PR DESCRIPTION
### 📌 작업 사항
---

- [구현] BasicButton 컴포넌트 구현
- [구현] BasicButton story 구현

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)
---

- 테두리 그라디언트는 정말 오랜 시간 노력했지만 뾰족한 방법이 나오지 않아 일단 포기했습니다..
- 그 외에도 그라디언트 때문에 코드가 더러워진 부분이 있는데 좋은 방법이 있으시면 말씀 해주세요!
- size variant를 넣었다가 시안을 확인해보니 반응형 사이즈에 따라 변경돼서 variant에서 제외했습니다.

### 📌 사용 방법 (선택)
---

- 기본적으로 부모의 너비에 꽉 차게 구현돼 있습니다. 크기를 지정하시려면 아래와 같이 className에 직접 지정하시면 됩니다. 그 외 스타일도 마찬가지 입니다.

```tsx
<BasicButton
  label="가입하기"
  variant={"secondary"}
  className="w-[33.5rem]"
  disabled
  onClick={() => console.log("클릭")}
/>
```

Close #4 

### 📌 스크린샷 / 테스트결과 (선택)

---
