### PR TITLE
feat: 카드 컴포넌트(statistics) 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs";
+import path from "path";
 
 const config: StorybookConfig = {
 	stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -15,6 +16,7 @@ const config: StorybookConfig = {
 	docs: {
 		autodocs: "tag",
 	},
+	staticDirs: ["../public"],
 	previewHead: (head) => `  
   ${head}
   <style>
@@ -23,5 +25,16 @@ const config: StorybookConfig = {
       }
     </style>
   `,
+	webpackFinal: async (config: any) => {
+		// Add path aliases
+		config.resolve.alias["@"] = path.resolve(__dirname, "../src");
+		config.resolve.alias["@/pages"] = path.resolve(__dirname, "../src/pages");
+		config.resolve.alias["@/components"] = path.resolve(
+			__dirname,
+			"../src/components",
+		);
+
+		return config;
+	},
 };
 export default config;

--- a/src/components/common/statisticscard/StatisticsCard.tsx
+++ b/src/components/common/statisticscard/StatisticsCard.tsx
@@ -1,0 +1,137 @@
+type StatisticsCardProps = {
+	type: "rate" | "like" | "review";
+	rateData?: number;
+	likeData?: number;
+	reviewData?: number;
+	rateAvg?: number;
+	likeAvg?: number;
+	reviewAvg?: number;
+};
+
+export default function StatisticsCard({
+	type,
+	rateData,
+	likeData,
+	reviewData,
+	rateAvg,
+	likeAvg,
+	reviewAvg,
+}: StatisticsCardProps) {
+	const typeLabel =
+		type === "rate" ? "별점 평균" : type === "like" ? "찜" : "리뷰";
+	const typeIcon =
+		type === "rate"
+			? "/icons/star.svg"
+			: type === "like"
+				? "/icons/heart_on.svg"
+				: "/icons/message.svg";
+	const reviewComma = reviewData?.toLocaleString("ko-KR");
+	const data =
+		type === "rate"
+			? rateData || 0
+			: type === "like"
+				? likeData || 0
+				: reviewData || 0;
+	const avgData =
+		type === "rate"
+			? rateAvg || 0
+			: type === "like"
+				? likeAvg || 0
+				: reviewAvg || 0;
+	function calculateDifference(data: number, avgData: number) {
+		const isBigger = data > avgData;
+		const isSame = data === avgData;
+		const diffRate = (isBigger ? data - avgData : avgData - data).toFixed(1);
+		const diffLikeNReview = Math.ceil(
+			isBigger ? data - avgData : avgData - data,
+		);
+		const biggerRate = isBigger && type === "rate";
+		const biggerLikeNReview =
+			(isBigger && type === "like") || (isBigger && type === "review");
+		const comparisonRate = biggerRate ? "더 높아요!" : "더 낮아요!";
+		const comparisonLikeNReview = biggerLikeNReview
+			? "더 많아요!"
+			: "더 적어요!";
+		return {
+			isSame,
+			diffRate,
+			diffLikeNReview,
+			comparisonRate,
+			comparisonLikeNReview,
+		};
+	}
+	const dataDiff = calculateDifference(data, avgData);
+
+	return (
+		<div className="flex flex-col justify-center rounded-[1.2rem] h-[8.2rem] min-w-[33.5rem] px-[2rem] border border-[#353542] bg-[#252530] md:items-center md:py-[3rem] md:gap-[2rem] md:min-w-[21.8rem] md:min-h-[16.9rem] lg:items-center lg:py-[3rem] lg:gap-[2rem] lg:w-full lg:h-full">
+			<div className="flex flex-row gap-[1rem]">
+				<span className="text-white text-[1.4rem] md:text-[1.6rem] lg:text-[1.8rem]">
+					{typeLabel}
+				</span>
+				<div className="flex items-center md:hidden lg:hidden">
+					<img
+						className="w-[1.9rem] h-[1.9rem] mr-[0.5rem] md:w-[2rem] md:h-[2rem] lg:w-[2.4rem] lg:h-[2.4rem]"
+						src={typeIcon}
+						alt={typeLabel}
+					/>
+					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem]">
+						{rateData}
+					</span>
+					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+						{likeData}
+					</span>
+					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+						{reviewComma}
+					</span>
+				</div>
+			</div>
+			<div className="hidden md:flex md:items-center lg:flex lg:items-center">
+				<img
+					className="w-[1.9rem] h-[1.9rem] mr-[0.5rem] md:w-[2rem] md:h-[2rem] lg:w-[2.4rem] lg:h-[2.4rem]"
+					src={typeIcon}
+					alt={typeLabel}
+				/>
+				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem]">
+					{rateData}
+				</span>
+				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+					{likeData}
+				</span>
+				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+					{reviewComma}
+				</span>
+			</div>
+			{!dataDiff.isSame && (
+				<div className="flex flex-row items-center text-[1.2rem] md:flex-col lg:text-[1.4rem] lg:flex-col">
+					<span className="text-gray-200">
+						같은 카테고리의 제품들보다&nbsp;
+					</span>
+					{rateData && (
+						<span className="text-gray-200">
+							<span className="text-white">{dataDiff.diffRate}점 </span>
+							{dataDiff.comparisonRate}
+						</span>
+					)}
+					{likeData && (
+						<span className="text-gray-200">
+							<span className="text-white">{dataDiff.diffLikeNReview}개 </span>
+							{dataDiff.comparisonLikeNReview}
+						</span>
+					)}
+					{reviewData && (
+						<span className="text-gray-200">
+							<span className="text-white">{dataDiff.diffLikeNReview}개 </span>
+							{dataDiff.comparisonLikeNReview}
+						</span>
+					)}
+				</div>
+			)}
+			{dataDiff.isSame && (
+				<div className="flex flex-row items-center text-[1.2rem] text-gray-200 md:flex-col lg:text-[1.4rem] lg:flex-col">
+					<span>같은 카테고리의 제품들과&nbsp;</span>
+					<span>동일해요!</span>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/common/statisticscard/StatisticsCard.tsx
+++ b/src/components/common/statisticscard/StatisticsCard.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image";
 
+import calculateDifference from "./calculateDifference";
+
 type StatisticsCardProps = {
 	type: "rate" | "like" | "review";
 	rateData?: number;
@@ -19,128 +21,84 @@ export default function StatisticsCard({
 	likeAvg,
 	reviewAvg,
 }: StatisticsCardProps) {
-	const typeLabel =
-		type === "rate" ? "별점 평균" : type === "like" ? "찜" : "리뷰";
-	const typeIcon =
-		type === "rate"
-			? "/icons/star.svg"
-			: type === "like"
-				? "/icons/heart_on.svg"
-				: "/icons/message.svg";
-	const reviewComma = reviewData?.toLocaleString("ko-KR");
-	const data =
-		type === "rate"
-			? rateData || 0
-			: type === "like"
-				? likeData || 0
-				: reviewData || 0;
-	const avgData =
-		type === "rate"
-			? rateAvg || 0
-			: type === "like"
-				? likeAvg || 0
-				: reviewAvg || 0;
-	function calculateDifference(data: number, avgData: number) {
-		const isBigger = data > avgData;
-		const isSame = data === avgData;
-		const diffRate = (isBigger ? data - avgData : avgData - data).toFixed(1);
-		const diffLikeNReview = Math.ceil(
-			isBigger ? data - avgData : avgData - data,
-		);
-		const biggerRate = isBigger && type === "rate";
-		const biggerLikeNReview =
-			(isBigger && type === "like") || (isBigger && type === "review");
-		const comparisonRate = biggerRate ? "더 높아요!" : "더 낮아요!";
-		const comparisonLikeNReview = biggerLikeNReview
-			? "더 많아요!"
-			: "더 적어요!";
-		return {
-			isSame,
-			diffRate,
-			diffLikeNReview,
-			comparisonRate,
-			comparisonLikeNReview,
-		};
-	}
-	const dataDiff = calculateDifference(data, avgData);
+	const typeList = {
+		rate: {
+			label: "별점 평균",
+			productData: rateData,
+			avgData: rateAvg,
+			icon: "/icons/star.svg",
+			unit: "점",
+			bottomDecription: {
+				higher: "더 높아요!",
+				lower: "더 낮아요!",
+				same: "동일해요!",
+			},
+		},
+		like: {
+			label: "찜",
+			productData: likeData,
+			avgData: likeAvg,
+			icon: "/icons/heart_on.svg",
+			unit: "개",
+			bottomDecription: {
+				higher: "더 많아요!",
+				lower: "더 적어요!",
+				same: "동일해요!",
+			},
+		},
+		review: {
+			label: "리뷰",
+			productData: reviewData,
+			avgData: reviewAvg,
+			icon: "/icons/message.svg",
+			unit: "개",
+			bottomDecription: {
+				higher: "더 많아요!",
+				lower: "더 적어요!",
+				same: "동일해요!",
+			},
+		},
+	};
 
+	const { label, productData, avgData, icon, unit, bottomDecription } =
+		typeList[type];
+
+	const result = calculateDifference(productData, avgData, bottomDecription);
 	return (
 		<div className="flex h-[8.2rem] min-w-[33.5rem] flex-col justify-center rounded-[1.2rem] border border-[#353542] bg-[#252530] px-[2rem] md:min-h-[16.9rem] md:min-w-[21.8rem] md:items-center md:gap-[2rem] lg:h-[19rem] lg:w-[30rem] lg:items-center lg:gap-[2rem]">
 			<div className="flex flex-row gap-[1rem]">
 				<span className="text-[1.4rem] text-white md:text-[1.6rem] lg:text-[1.8rem]">
-					{typeLabel}
+					{label}
 				</span>
 				<div className="flex items-center md:hidden lg:hidden">
 					<div className="relative mr-[0.5rem] size-[1.9rem]  md:size-[2rem] lg:size-[2.4rem]">
-						<Image
-							src={typeIcon}
-							alt={typeLabel}
-							fill
-							className="object-cover"
-						/>
+						<Image src={icon} alt={label} fill className="object-cover" />
 					</div>
-
 					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem]">
-						{rateData}
-					</span>
-					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
-						{likeData}
-					</span>
-					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
-						{reviewComma}
+						{type === "rate" ? productData : productData?.toLocaleString()}
 					</span>
 				</div>
 			</div>
 			<div className="hidden md:flex md:items-center lg:flex lg:items-center">
 				<div className="relative mr-[0.5rem] size-[1.9rem]  md:size-[2rem] lg:size-[2.4rem]">
-					<Image
-						src={typeIcon}
-						alt={typeLabel}
-						fill
-						className="object-cover "
-					/>
+					<Image src={icon} alt={label} fill className="object-cover " />
 				</div>
 				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem]">
-					{rateData}
-				</span>
-				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
-					{likeData}
-				</span>
-				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
-					{reviewComma}
+					{type === "rate" ? productData : productData?.toLocaleString()}
 				</span>
 			</div>
-			{!dataDiff.isSame && (
-				<div className="flex flex-row items-center text-[1.2rem] md:flex-col lg:flex-col lg:text-[1.4rem]">
-					<span className="text-gray-200">
-						같은 카테고리의 제품들보다&nbsp;
-					</span>
-					{rateData && (
-						<span className="text-gray-200">
-							<span className="text-white">{dataDiff.diffRate}점 </span>
-							{dataDiff.comparisonRate}
+			<div className="flex flex-row items-center text-[1.2rem] md:flex-col lg:flex-col lg:text-[1.4rem]">
+				<span className="text-gray-200">{result.topDescription}&nbsp;</span>
+				<span className="text-gray-200">
+					{!result.isSame && (
+						<span className="text-white">
+							{type === "rate" ? result.rateDiff : result.likeReviewDiff}
+							{unit}&nbsp;
 						</span>
 					)}
-					{likeData && (
-						<span className="text-gray-200">
-							<span className="text-white">{dataDiff.diffLikeNReview}개 </span>
-							{dataDiff.comparisonLikeNReview}
-						</span>
-					)}
-					{reviewData && (
-						<span className="text-gray-200">
-							<span className="text-white">{dataDiff.diffLikeNReview}개 </span>
-							{dataDiff.comparisonLikeNReview}
-						</span>
-					)}
-				</div>
-			)}
-			{dataDiff.isSame && (
-				<div className="flex flex-row items-center text-[1.2rem] text-gray-200 md:flex-col lg:flex-col lg:text-[1.4rem]">
-					<span>같은 카테고리의 제품들과&nbsp;</span>
-					<span>동일해요!</span>
-				</div>
-			)}
+					{result.bottomDescriptionResult}
+				</span>
+			</div>
 		</div>
 	);
 }

--- a/src/components/common/statisticscard/StatisticsCard.tsx
+++ b/src/components/common/statisticscard/StatisticsCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-export type StatisticsCardProps = {
+type StatisticsCardProps = {
 	type: "rate" | "like" | "review";
 	rateData?: number;
 	likeData?: number;

--- a/src/components/common/statisticscard/StatisticsCard.tsx
+++ b/src/components/common/statisticscard/StatisticsCard.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export type StatisticsCardProps = {
 	type: "rate" | "like" | "review";
 	rateData?: number;
@@ -63,46 +65,53 @@ export default function StatisticsCard({
 	const dataDiff = calculateDifference(data, avgData);
 
 	return (
-		<div className="flex flex-col justify-center rounded-[1.2rem] min-w-[33.5rem] h-[8.2rem] px-[2rem] border border-[#353542] bg-[#252530] md:items-center md:gap-[2rem] md:min-w-[21.8rem] md:min-h-[16.9rem] lg:items-center lg:gap-[2rem] lg:w-[30rem] lg:h-[19rem]">
+		<div className="flex h-[8.2rem] min-w-[33.5rem] flex-col justify-center rounded-[1.2rem] border border-[#353542] bg-[#252530] px-[2rem] md:min-h-[16.9rem] md:min-w-[21.8rem] md:items-center md:gap-[2rem] lg:h-[19rem] lg:w-[30rem] lg:items-center lg:gap-[2rem]">
 			<div className="flex flex-row gap-[1rem]">
-				<span className="text-white text-[1.4rem] md:text-[1.6rem] lg:text-[1.8rem]">
+				<span className="text-[1.4rem] text-white md:text-[1.6rem] lg:text-[1.8rem]">
 					{typeLabel}
 				</span>
 				<div className="flex items-center md:hidden lg:hidden">
-					<img
-						className="w-[1.9rem] h-[1.9rem] mr-[0.5rem] md:w-[2rem] md:h-[2rem] lg:w-[2.4rem] lg:h-[2.4rem]"
-						src={typeIcon}
-						alt={typeLabel}
-					/>
-					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem]">
+					<div className="relative mr-[0.5rem] size-[1.9rem]  md:size-[2rem] lg:size-[2.4rem]">
+						<Image
+							src={typeIcon}
+							alt={typeLabel}
+							fill
+							className="object-cover"
+						/>
+					</div>
+
+					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem]">
 						{rateData}
 					</span>
-					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
 						{likeData}
 					</span>
-					<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+					<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
 						{reviewComma}
 					</span>
 				</div>
 			</div>
 			<div className="hidden md:flex md:items-center lg:flex lg:items-center">
-				<img
-					className="w-[1.9rem] h-[1.9rem] mr-[0.5rem] md:w-[2rem] md:h-[2rem] lg:w-[2.4rem] lg:h-[2.4rem]"
-					src={typeIcon}
-					alt={typeLabel}
-				/>
-				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem]">
+				<div className="relative mr-[0.5rem] size-[1.9rem]  md:size-[2rem] lg:size-[2.4rem]">
+					<Image
+						src={typeIcon}
+						alt={typeLabel}
+						fill
+						className="object-cover "
+					/>
+				</div>
+				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem]">
 					{rateData}
 				</span>
-				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
 					{likeData}
 				</span>
-				<span className="text-gray-100 text-[1.6rem] md:text-[2rem] lg:text-[2.4rem] ">
+				<span className="text-[1.6rem] text-gray-100 md:text-[2rem] lg:text-[2.4rem] ">
 					{reviewComma}
 				</span>
 			</div>
 			{!dataDiff.isSame && (
-				<div className="flex flex-row items-center text-[1.2rem] md:flex-col lg:text-[1.4rem] lg:flex-col">
+				<div className="flex flex-row items-center text-[1.2rem] md:flex-col lg:flex-col lg:text-[1.4rem]">
 					<span className="text-gray-200">
 						같은 카테고리의 제품들보다&nbsp;
 					</span>
@@ -127,7 +136,7 @@ export default function StatisticsCard({
 				</div>
 			)}
 			{dataDiff.isSame && (
-				<div className="flex flex-row items-center text-[1.2rem] text-gray-200 md:flex-col lg:text-[1.4rem] lg:flex-col">
+				<div className="flex flex-row items-center text-[1.2rem] text-gray-200 md:flex-col lg:flex-col lg:text-[1.4rem]">
 					<span>같은 카테고리의 제품들과&nbsp;</span>
 					<span>동일해요!</span>
 				</div>

--- a/src/components/common/statisticscard/StatisticsCard.tsx
+++ b/src/components/common/statisticscard/StatisticsCard.tsx
@@ -1,4 +1,4 @@
-type StatisticsCardProps = {
+export type StatisticsCardProps = {
 	type: "rate" | "like" | "review";
 	rateData?: number;
 	likeData?: number;
@@ -63,7 +63,7 @@ export default function StatisticsCard({
 	const dataDiff = calculateDifference(data, avgData);
 
 	return (
-		<div className="flex flex-col justify-center rounded-[1.2rem] h-[8.2rem] min-w-[33.5rem] px-[2rem] border border-[#353542] bg-[#252530] md:items-center md:py-[3rem] md:gap-[2rem] md:min-w-[21.8rem] md:min-h-[16.9rem] lg:items-center lg:py-[3rem] lg:gap-[2rem] lg:w-full lg:h-full">
+		<div className="flex flex-col justify-center rounded-[1.2rem] min-w-[33.5rem] h-[8.2rem] px-[2rem] border border-[#353542] bg-[#252530] md:items-center md:gap-[2rem] md:min-w-[21.8rem] md:min-h-[16.9rem] lg:items-center lg:gap-[2rem] lg:w-[30rem] lg:h-[19rem]">
 			<div className="flex flex-row gap-[1rem]">
 				<span className="text-white text-[1.4rem] md:text-[1.6rem] lg:text-[1.8rem]">
 					{typeLabel}

--- a/src/components/common/statisticscard/calculateDifference.ts
+++ b/src/components/common/statisticscard/calculateDifference.ts
@@ -1,0 +1,41 @@
+type decriptionType = {
+	higher: string;
+	lower: string;
+	same: string;
+};
+
+export default function calculateDifference(
+	productData: number | undefined,
+	avgData: number | undefined,
+	bottomDecription: decriptionType,
+) {
+	const isHigher = (productData || 0) > (avgData || 0);
+	const isLower = (avgData || 0) > (productData || 0);
+	const isSame = productData === avgData;
+	const rateDiff = (
+		isHigher
+			? (productData || 0) - (avgData || 0)
+			: (avgData || 0) - (productData || 0)
+	).toFixed(1);
+	const likeReviewDiff = Math.ceil(
+		isHigher
+			? (productData || 0) - (avgData || 0)
+			: (avgData || 0) - (productData || 0),
+	);
+	const topDescription = isSame
+		? "같은 카테고리의 제품들과"
+		: "같은 카테고리의 제품들보다";
+
+	const bottomDescriptionResult = isHigher
+		? bottomDecription.higher
+		: isLower
+			? bottomDecription.lower
+			: bottomDecription.same;
+	return {
+		isSame,
+		rateDiff,
+		likeReviewDiff,
+		topDescription,
+		bottomDescriptionResult,
+	};
+}

--- a/src/stories/StatisticsCard.stories.ts
+++ b/src/stories/StatisticsCard.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import StatisticsCard from "@/components/common/statisticscard/StatisticsCard";
+
+const meta = {
+	title: "Components/Common/StatisticsCard",
+	component: StatisticsCard,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof StatisticsCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Rate: Story = {
+	args: {
+		type: "rate",
+		rateData: 4.9,
+		rateAvg: 4.1,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		likeData: { control: { disable: true } },
+		likeAvg: { control: { disable: true } },
+		reviewData: { control: { disable: true } },
+		reviewAvg: { control: { disable: true } },
+	},
+};
+
+export const Like: Story = {
+	args: {
+		type: "like",
+		likeData: 566,
+		likeAvg: 589,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		rateData: { control: { disable: true } },
+		rateAvg: { control: { disable: true } },
+		reviewData: { control: { disable: true } },
+		reviewAvg: { control: { disable: true } },
+	},
+};
+
+export const Review: Story = {
+	args: {
+		type: "review",
+		reviewData: 4123,
+		reviewAvg: 3937,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		rateData: { control: { disable: true } },
+		rateAvg: { control: { disable: true } },
+		likeData: { control: { disable: true } },
+		likeAvg: { control: { disable: true } },
+	},
+};
+
+export const equal: Story = {
+	args: {
+		type: "review",
+		reviewData: 4123,
+		reviewAvg: 4123,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		rateData: { control: { disable: true } },
+		rateAvg: { control: { disable: true } },
+		likeData: { control: { disable: true } },
+		likeAvg: { control: { disable: true } },
+	},
+};

--- a/src/stories/StatisticsCard.stories.ts
+++ b/src/stories/StatisticsCard.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
 import StatisticsCard from "@/components/common/statisticscard/StatisticsCard";
 
 const meta = {
@@ -59,7 +60,7 @@ export const Review: Story = {
 	},
 };
 
-export const equal: Story = {
+export const Equal: Story = {
 	args: {
 		type: "review",
 		reviewData: 4123,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,7 +16,7 @@
 	}
 }
 
-body {
+html {
 	font-size: 62.5%;
 	font-family: "Pretendard";
 }


### PR DESCRIPTION
- Close #22 

### 📌 작업 사항

---
- [구현] statistics 카드 컴포넌트 구현

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 스토리북 상에서 type(아래 props 참고)과  해당 type에 들어갈 수 없는 다른 데이터들은 컨트롤하지 못하도록`control: { disable: true }`로 제한하였습니다. 그리고 각 type prop마다 스토리를 따로 생성하였습니다.
- 스토리북에서 public폴더를 인식 못해서 아이콘을 못불러오더라고요 ㅎㅎ 경로 연결을 하기 위해 .storybook/main.ts 파일을 수정하였습니다.
    - `staticDirs: ["../public"]` 추가
    - 참고 사이트 : https://devpluto.tistory.com/entry/Nextjs-Next%EC%97%90%EC%84%9C-Styled-Components%EC%99%80-%ED%95%A8%EA%BB%98-Storybook-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0


### 📌 사용 방법 (선택)

---
- props
    - type : "rate" | "like" | "review" (rate : 별점, like : 찜 , review : 리뷰) 타입 별로 디자인 변경
    - rateData : 상품의 별점
    - rateAvg : 카테고리의 평균 별점
    - likeData : 상품의 찜 개수
    - likeAvg : 카테고리의 평균 찜 개수
    - reviewData : 상품의 리뷰 개수
    - reviewAvg : 카테고리의 평균 리뷰 개수
- type prop에 해당하는 데이터props를 컴포넌트에 같이 전달하시면 됩니다.
- 예시
```
<StatisticsCard type="rate" rateData={4.9} rateAvg={4.1} />
<StatisticsCard type="like" likeData={566} likeAvg={589} />
<StatisticsCard type="review" reviewData={4123} reviewAvg={3937} />
```
### 📌 스크린샷 / 테스트결과 (선택)

---
![별점](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/2bcca416-1b9c-47da-8827-3b0251155c9d)
![찜](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/b68b7370-55b1-4edb-8720-d12ce31fb0f9)
![리뷰](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/705e5dd2-69bc-4006-bea2-a9a48466ab17)
![같음](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/375a7812-cb38-417a-8fc2-13742a9aba25)

