### PR TITLE
feat: 닉네임 컴포넌트 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs";
+import path from "path";
 
 const config: StorybookConfig = {
 	stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -23,5 +24,16 @@ const config: StorybookConfig = {
       }
     </style>
   `,
+	webpackFinal: async (config: any) => {
+		// Add path aliases
+		config.resolve.alias["@"] = path.resolve(__dirname, "../src");
+		config.resolve.alias["@/pages"] = path.resolve(__dirname, "../src/pages");
+		config.resolve.alias["@/components"] = path.resolve(
+			__dirname,
+			"../src/components",
+		);
+
+		return config;
+	},
 };
 export default config;

--- a/src/components/common/nickname/Nickname.tsx
+++ b/src/components/common/nickname/Nickname.tsx
@@ -1,0 +1,27 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import React from "react";
+
+import cn from "@/utils/cn";
+
+/**
+ * small - 유저 랭킹 컴포넌트
+ * large - 팔로워 컴포넌트
+ */
+const nicknameVariants = cva("text-white", {
+	variants: {
+		size: {
+			small: "text-[1.4rem] lg:text-[1.6rem]",
+			large: "text-[1.6rem] font-medium lg:text-[1.8rem]",
+		},
+	},
+});
+
+type Props = React.HTMLAttributes<HTMLSpanElement> &
+	VariantProps<typeof nicknameVariants> & {
+		size: "small" | "large";
+		nickname: string;
+	};
+
+export default function Nickname({ nickname, size }: Props) {
+	return <span className={cn(nicknameVariants({ size }))}>{nickname}</span>;
+}

--- a/src/stories/Nickname.stories.ts
+++ b/src/stories/Nickname.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Nickname from "@/components/common/nickname/Nickname";
+
+const meta = {
+	title: "Components/Common/Nickname",
+	component: Nickname,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof Nickname>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Small: Story = {
+	args: {
+		size: "small",
+		nickname: "리뷰왕",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		size: "large",
+		nickname: "미끄럼틀",
+	},
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,7 +16,7 @@
 	}
 }
 
-body {
+html {
 	font-size: 62.5%;
 	font-family: "Pretendard";
 }

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export default function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Close #13 

### 📌 작업 사항

---

- [구현] 랭킹 컴포넌트, 팔로워 컴포넌트에서 사용하는 닉네임 컴포넌트 구현

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 작성할 컴포넌트를 나누고, 생각없이 그냥 그 컴포넌트 단위로 이슈를 생성하다보니 pr를 너무 작게 & 많이 올리는 것 같은데, 그래도 큰 것 보다는 나으니까..?요...?ㅋㅋㅋ (NickName.tsx 파일만 보면 되는 거라 사실 코드 26줄짜리 pr이네요 ㅋㅋㅋㅋㅋㅋ)
- size="small" 은 유저 랭킹 컴포넌트에서 size="large"는 팔로워 컴포넌트에서 사용하는데, `size: "small" | "large";`로 작성하면 되겠죠?ㅋㅋ

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
<img width="805" alt="스크린샷 2024-03-06 오후 11 19 38" src="https://github.com/4-2-mogazoa/mogazoa/assets/141597336/df359e89-a706-421e-af31-fc4cc7d3fbbb">

