### PR TITLE
feat: 상품 이름 태그 컴포넌트 구현

### DIFF
--- a/src/components/common/productNameTag/ProductNameTag.tsx
+++ b/src/components/common/productNameTag/ProductNameTag.tsx
@@ -1,0 +1,46 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import Image from "next/image";
+import React from "react";
+
+import cn from "@/utils/cn";
+
+const productNameTagVariants = cva(
+	"_flex-center w-fit gap-4 rounded-[0.6rem] px-[1rem] py-[0.8rem] text-[1.4rem] md:text-[1.6rem]",
+	{
+		variants: {
+			color: {
+				green: "bg-green/10 text-green",
+				pink: "bg-pink/10 text-pink",
+			},
+		},
+	},
+);
+
+type Props = React.HTMLAttributes<HTMLDivElement> &
+	VariantProps<typeof productNameTagVariants> & {
+		color: "green" | "pink";
+		productName: string;
+		handleDeleteButtonClick: () => void;
+	};
+
+export default function ProductNameTag({
+	color,
+	productName,
+	handleDeleteButtonClick,
+}: Props) {
+	const deleteIconSrc = "/icons/close.svg";
+
+	return (
+		<div className={cn(productNameTagVariants({ color }))}>
+			{productName}
+			<button
+				className="_flex-center size-[1.7rem] rounded-[0.6rem] bg-[#000000]/50 p-[0.2rem] md:size-[1.9rem]"
+				onClick={handleDeleteButtonClick}
+			>
+				<div className="relative size-[1.3rem] md:size-[1.5rem]">
+					<Image src={deleteIconSrc} alt="상품 삭제하기" fill />
+				</div>
+			</button>
+		</div>
+	);
+}

--- a/src/components/common/productNameTag/ProductNameTag.tsx
+++ b/src/components/common/productNameTag/ProductNameTag.tsx
@@ -31,16 +31,16 @@ export default function ProductNameTag({
 	const deleteIconSrc = "/icons/close.svg";
 
 	return (
-		<div className={cn(productNameTagVariants({ color }))}>
+		<button
+			className={cn(productNameTagVariants({ color }))}
+			onClick={handleDeleteButtonClick}
+		>
 			{productName}
-			<button
-				className="_flex-center size-[1.7rem] rounded-[0.6rem] bg-[#000000]/50 p-[0.2rem] md:size-[1.9rem]"
-				onClick={handleDeleteButtonClick}
-			>
+			<div className="_flex-center size-[1.7rem] rounded-[0.6rem] bg-[#000000]/50 p-[0.2rem] md:size-[1.9rem]">
 				<div className="relative size-[1.3rem] md:size-[1.5rem]">
 					<Image src={deleteIconSrc} alt="상품 삭제하기" fill />
 				</div>
-			</button>
-		</div>
+			</div>
+		</button>
 	);
 }

--- a/src/stories/ProductNameTag.stories.ts
+++ b/src/stories/ProductNameTag.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+
+import ProductNameTag from "@/components/common/productNameTag/ProductNameTag";
+
+const meta = {
+	title: "Components/Common/ProductNameTag",
+	component: ProductNameTag,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof ProductNameTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Green: Story = {
+	args: {
+		color: "green",
+		productName: "비교 상품 1",
+	},
+};
+
+export const Pink: Story = {
+	args: {
+		color: "pink",
+		productName: "비교 상품 2",
+	},
+};
+
+export const ClickDeleteButton = {
+	args: {
+		color: "pink",
+		productName: "비교 상품 2",
+		handleDeleteButtonClick: () => alert("삭제됨!"),
+	},
+	play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		await userEvent.click(button);
+	},
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,17 @@ html {
 	.text-main-gradient {
 		@apply bg-main-gradient bg-clip-text text-transparent;
 	}
+
+	._flex-center {
+		@apply flex items-center justify-center;
+	}
+
+	._flex-col-center {
+		@apply flex flex-col items-center justify-center;
+	}
+	._pos-center {
+		@apply top-2/4 left-2/4 -translate-x-2/4 -translate-y-2/4;
+	}
 }
 
 @font-face {


### PR DESCRIPTION
Close #21 

### 📌 작업 사항

---

- [구현] 비교할 상품 이름을 입력하고 엔터를 입력했을 때 보여주는 상품 이름 태그 컴포넌트 구현

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
-고민: x 버튼을 눌렀을 때만 삭제되도록 하기 vs 태그 전체 중 아무곳이나 눌렀을 때 삭제되도록 하기

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
![image](https://github.com/4-2-mogazoa/mogazoa/assets/141597336/190bfca1-20bd-4ca2-9b7f-9b3b14d9a020)

