### PR TITLE
feat: 카드 컴포넌트(Activity) 구현 

### DIFF
--- a/src/components/common/activitycard/ActivityCard.tsx
+++ b/src/components/common/activitycard/ActivityCard.tsx
@@ -1,0 +1,86 @@
+import Image from "next/image";
+
+import CategoryBadge from "../categoryBadge/CategoryBadge";
+
+type Props = {
+	type: "rate" | "review" | "category";
+	myRateAvg?: number;
+	myReivewCount?: number;
+	category?:
+		| "음악"
+		| "영화/드라마"
+		| "강의/책"
+		| "호텔"
+		| "가구/인테리어"
+		| "식당"
+		| "전자기기"
+		| "화장품"
+		| "의류/잡화"
+		| "앱";
+};
+
+export default function ActivityCard({
+	type,
+	myRateAvg,
+	myReivewCount,
+	category = "음악",
+}: Props) {
+	const typeList = {
+		rate: {
+			label: "남긴 별점 평균",
+			mobileLabel: ["남긴", "별점 평균"],
+			img: "/icons/star.svg",
+			data: myRateAvg?.toFixed(1),
+			isReview: false,
+		},
+		review: {
+			label: "남긴 리뷰",
+			mobileLabel: ["남긴 리뷰"],
+			img: "/icons/message.svg",
+			data: myReivewCount?.toLocaleString(),
+			isReview: true,
+		},
+		category: {
+			label: "관심 카테고리",
+			mobileLabel: ["관심", "카테고리"],
+			img: "",
+			data: category,
+			isReview: false,
+		},
+	};
+
+	const { label, img, mobileLabel, data, isReview } = typeList[type];
+
+	return (
+		<div className="flex h-[11.9rem] w-[10.5rem] flex-col items-center justify-center gap-[1.5rem] rounded-[1.2rem] border border-[#353542] bg-[#252530] md:w-[16.3rem] lg:h-[12.8rem] lg:w-[30rem] lg:gap-[2rem]">
+			<div className="hidden text-[1.4rem] text-gray-100 md:flex lg:flex lg:text-[1.6rem]">
+				{label}
+			</div>
+			{!isReview && (
+				<div className="flex text-center text-[1.4rem] text-gray-100 md:hidden lg:hidden lg:text-[1.6rem]">
+					{mobileLabel[0]}
+					<br />
+					{mobileLabel[1]}
+				</div>
+			)}
+			{isReview && (
+				<div className="flex py-[1rem] text-center text-[1.4rem] text-gray-100 md:hidden lg:hidden lg:text-[1.6rem]">
+					{mobileLabel[0]}
+					<br />
+					{mobileLabel[1]}
+				</div>
+			)}
+			{img && (
+				<div className="flex flex-row items-center ">
+					<div className="relative mr-[0.5rem] size-[2rem] lg:size-[2.4rem]">
+						<Image src={img} alt={label} fill className="object-cover" />
+					</div>
+					<span className="text-[2rem] text-white lg:text-[2.4rem]">
+						{data}
+					</span>
+				</div>
+			)}
+			{!img && <CategoryBadge size="responsive" category={category} />}
+		</div>
+	);
+}

--- a/src/components/common/activitycard/ActivityCard.tsx
+++ b/src/components/common/activitycard/ActivityCard.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import Image from "next/image";
 
 import CategoryBadge from "../categoryBadge/CategoryBadge";
@@ -19,61 +20,66 @@ type Props = {
 		| "앱";
 };
 
+type dataType = {
+	label: string[];
+	img?: string;
+	data: number | string | undefined;
+};
+
+type DataListType = {
+	rate: dataType;
+	review: dataType;
+	category: dataType;
+};
+
 export default function ActivityCard({
 	type,
 	myRateAvg,
 	myReivewCount,
 	category = "음악",
 }: Props) {
-	const typeList = {
+	const DataList: DataListType = {
 		rate: {
-			label: "남긴 별점 평균",
-			mobileLabel: ["남긴", "별점 평균"],
+			label: ["남긴", "별점 평균"],
 			img: "/icons/star.svg",
 			data: myRateAvg?.toFixed(1),
-			isReview: false,
 		},
 		review: {
-			label: "남긴 리뷰",
-			mobileLabel: ["남긴 리뷰"],
+			label: ["남긴 리뷰"],
 			img: "/icons/message.svg",
 			data: myReivewCount?.toLocaleString(),
-			isReview: true,
 		},
 		category: {
-			label: "관심 카테고리",
-			mobileLabel: ["관심", "카테고리"],
-			img: "",
+			label: ["관심", "카테고리"],
 			data: category,
-			isReview: false,
 		},
 	};
-
-	const { label, img, mobileLabel, data, isReview } = typeList[type];
+	const { label, img, data } = DataList[type];
 
 	return (
 		<div className="flex h-[11.9rem] w-[10.5rem] flex-col items-center justify-center gap-[1.5rem] rounded-[1.2rem] border border-[#353542] bg-[#252530] md:w-[16.3rem] lg:h-[12.8rem] lg:w-[30rem] lg:gap-[2rem]">
-			<div className="hidden text-[1.4rem] text-gray-100 md:flex lg:flex lg:text-[1.6rem]">
-				{label}
+			<div className="hidden text-[1.4rem] text-gray-100 md:flex lg:text-[1.6rem]">
+				{label.join(" ")}
 			</div>
-			{!isReview && (
-				<div className="flex text-center text-[1.4rem] text-gray-100 md:hidden lg:hidden lg:text-[1.6rem]">
-					{mobileLabel[0]}
-					<br />
-					{mobileLabel[1]}
-				</div>
-			)}
-			{isReview && (
-				<div className="flex py-[1rem] text-center text-[1.4rem] text-gray-100 md:hidden lg:hidden lg:text-[1.6rem]">
-					{mobileLabel[0]}
-					<br />
-					{mobileLabel[1]}
-				</div>
-			)}
+			<div
+				className={clsx(
+					"flex text-center text-[1.4rem] text-gray-100 md:hidden lg:text-[1.6rem]",
+					{ "py-[1rem]": type === "review" },
+				)}
+			>
+				{label[0]}
+				<br />
+				{label[1]}
+			</div>
 			{img && (
 				<div className="flex flex-row items-center ">
 					<div className="relative mr-[0.5rem] size-[2rem] lg:size-[2.4rem]">
-						<Image src={img} alt={label} fill className="object-cover" />
+						<Image
+							src={img}
+							alt={label.join("")}
+							fill
+							className="object-cover"
+						/>
 					</div>
 					<span className="text-[2rem] text-white lg:text-[2.4rem]">
 						{data}

--- a/src/stories/ActivityCard.stories.ts
+++ b/src/stories/ActivityCard.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import ActivityCard from "@/components/common/activitycard/ActivityCard";
+
+const meta = {
+	title: "Components/Common/ActivityCard",
+	component: ActivityCard,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof ActivityCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Rate: Story = {
+	args: {
+		type: "rate",
+		myRateAvg: 4.1,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		myReivewCount: { control: { disable: true } },
+		category: { control: { disable: true } },
+	},
+};
+
+export const MyReivewCount: Story = {
+	args: {
+		type: "review",
+		myReivewCount: 125,
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		myRateAvg: { control: { disable: true } },
+		category: { control: { disable: true } },
+	},
+};
+
+export const Category: Story = {
+	args: {
+		type: "category",
+		category: "전자기기",
+	},
+	argTypes: {
+		type: { control: { disable: true } },
+		myRateAvg: { control: { disable: true } },
+		myReivewCount: { control: { disable: true } },
+	},
+};


### PR DESCRIPTION
- Close #38 
### 📌 작업 사항

---
- [구현] 카드 컴포넌트(Activity) 구현 

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 카테고리 별점 평균과 동일하게 내 별점 평균도 백엔드에서는 제공하지 않는것으로 보이는데요..ㅎㅎ 
내 정보 조회에서는 따로 별점에 대한 값을 받아오지 않고, 유저가 리뷰한 상품 조회도  해당 상품 자체 별점만 데이터로 받는거 같아요. 특정 유저가 남긴 별점의 평균을 어떻게 구현해야할지 잘 모르겠네요.
- 내 정보 조회 response
```{
  "updatedAt": "2024-03-07T13:19:28.709Z",
  "createdAt": "2024-03-07T13:19:28.709Z",
  "teamId": "string",
  "image": "https://example.com/...",
  "nickname": "string",
  "id": 0,
  "followeesCount": 0,
  "followersCount": 0,
  "isFollowing": true
}
```
- 유저가 리뷰한 상품 조회 response
```
{
  "nextCursor": 0,
  "list": [
    {
      "updatedAt": "2024-03-07T13:20:39.549Z",
      "createdAt": "2024-03-07T13:20:39.549Z",
      "writerId": 0,
      "categoryId": 0,
      "favoriteCount": 0,
      "reviewCount": 0,
      "rating": 0,
      "image": "https://example.com/...",
      "name": "string",
      "id": 0
    }
  ]
}
```

### 📌 사용 방법 (선택)

---
- 아래 예시와 같이 type prop에 맞는 데이터 prop을 같이 전달하시면 됩니다.
```
<ActivityCard type="rate" myRateAvg={4.1} />
<ActivityCard type="review" myReivewCount={125} />
<ActivityCard type="category" category="전자기기" />
```

### 📌 스크린샷 / 테스트결과 (선택)

---
![1](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/323d9ace-1b73-4466-a3f1-3cc060a1d7e7)
![2](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/5d83ff65-3443-4961-abe7-9a0166b8be6e)
![3](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/8de51106-854d-4537-8d5b-5a0a0ade3eae)


