### PR TITLE
Feat: 드랍다운 컴포넌트 구현

### DIFF
--- a/src/components/common/button/BasicButton.tsx
+++ b/src/components/common/button/BasicButton.tsx
@@ -1,7 +1,8 @@
 import { cva, VariantProps } from "class-variance-authority";
 import clsx from "clsx";
 import { ButtonHTMLAttributes } from "react";
-import { twMerge } from "tailwind-merge";
+
+import cn from "@/utils/cn";
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> &
 	VariantProps<typeof buttonVariants> & {
@@ -36,7 +37,7 @@ export default function BasicButton({
 }: Props) {
 	return (
 		<button
-			className={twMerge(buttonVariants({ variant }), className)}
+			className={cn(buttonVariants({ variant }), className)}
 			disabled={disabled}
 			{...props}
 		>

--- a/src/components/common/button/BasicButton.tsx
+++ b/src/components/common/button/BasicButton.tsx
@@ -1,5 +1,4 @@
 import { cva, VariantProps } from "class-variance-authority";
-import clsx from "clsx";
 import { ButtonHTMLAttributes } from "react";
 
 import cn from "@/utils/cn";
@@ -42,7 +41,7 @@ export default function BasicButton({
 			{...props}
 		>
 			<span
-				className={clsx(
+				className={cn(
 					variant === "secondary" && !disabled && "text-main-gradient",
 				)}
 			>

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -42,7 +42,7 @@ type Props<T extends Item> = {
 	children: ReactNode;
 };
 
-export default function Dropdown<T extends Item>({
+function Dropdown<T extends Item>({
 	items,
 	defaultItem,
 	onSelect,
@@ -97,3 +97,5 @@ export default function Dropdown<T extends Item>({
 Dropdown.Button = DropdownToggleButton;
 Dropdown.Input = DropdownFilterInput;
 Dropdown.List = DropdownList;
+
+export default Dropdown;

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,185 +1,95 @@
-import { cva, VariantProps } from "class-variance-authority";
 import clsx from "clsx";
-import { motion } from "framer-motion";
-import Image from "next/image";
-import { ChangeEvent, HTMLAttributes, useRef, useState } from "react";
+import {
+	createContext,
+	Dispatch,
+	ReactNode,
+	RefObject,
+	SetStateAction,
+	useState,
+} from "react";
 
 import useOutsideClick from "@/hooks/common/useOutsideClick";
-import cn from "@/utils/cn";
 
-type Props<T extends { id: number; name: string }> =
-	HTMLAttributes<HTMLElement> &
-		VariantProps<typeof dropdownVariants> & {
-			placeholder: string;
-			items: Array<T>;
-			onSelectItem: (item: T) => void;
-		};
+import DropdownFilterInput from "./DropdownFilterInput";
+import DropdownList from "./DropdownList";
+import DropdownToggleButton from "./DropdownToggleButton";
 
-const dropdownVariants = cva(
-	"flex w-full items-center justify-between rounded-[0.8rem] ",
-	{
-		variants: {
-			variant: {
-				dropdown:
-					"bg-[#252530] px-[2rem] py-[1.25rem] outline outline-[#353542] md:py-[1.5rem] lg:py-[2rem]",
-				smallDropdown: "w-[6.2rem] md:w-[14rem] lg:w-[16rem]",
-				filteredDropdown:
-					"bg-[#252530] px-[2rem] py-[1.7rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.95rem] lg:py-[2.3rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
-			},
-		},
-	},
-);
+export type Item = {
+	id: number;
+	name: string;
+};
 
-export default function Dropdown<T extends { id: number; name: string }>({
-	variant,
+type DropdownContextType<T extends Item> = {
+	isOpen: boolean;
+	setIsOpen: Dispatch<SetStateAction<boolean>>;
+	placeholder: string;
+	selectedItem: T | null;
+	setSelectedItem: Dispatch<SetStateAction<T | null>>;
+	onSelect: (item: T) => void;
+	setFilterQuery: Dispatch<SetStateAction<string>>;
+	filteredItems: T[];
+	setButtonVariant: Dispatch<SetStateAction<string>>;
+	inputRef: RefObject<HTMLInputElement> | null;
+	setInputRef: Dispatch<SetStateAction<RefObject<HTMLInputElement> | null>>;
+};
+
+export const DropdownContext = createContext<DropdownContextType<any>>(null!);
+
+type Props<T extends Item> = {
+	items: T[];
+	placeholder: string;
+	onSelect: (item: T) => void;
+	children: ReactNode;
+};
+
+export default function Dropdown<T extends Item>({
 	placeholder,
 	items,
-	onSelectItem,
-	...props
+	onSelect,
+	children,
 }: Props<T>) {
 	const [isOpen, setIsOpen] = useState(false);
-	const [selectedItem, setSelectedItem] = useState<T>();
 	const [filterQuery, setFilterQuery] = useState("");
+	const [selectedItem, setSelectedItem] = useState<T | null>(null);
+	const [buttonVariant, setButtonVariant] = useState("");
+	const [inputRef, setInputRef] = useState<RefObject<HTMLInputElement> | null>(
+		null,
+	);
+
 	const dropdownRef = useOutsideClick<HTMLDivElement>(() => setIsOpen(false));
-	const inputRef = useRef<HTMLInputElement>(null);
 
 	const filteredItems = items.filter((item) => item.name.includes(filterQuery));
 
-	const dropdownIcon = "/icons/drop_down.svg";
-
-	const handleSelectItem = (item: T) => {
-		setSelectedItem(item);
-		setIsOpen(false);
-		onSelectItem(item);
-
-		if (variant === "filteredDropdown" && inputRef.current) {
-			inputRef.current.value = item.name;
-		}
-	};
-
-	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-		const query = e.target.value;
-
-		if (!query.length) {
-			setFilterQuery(query);
-			setIsOpen(false);
-			return;
-		}
-
-		setFilterQuery(query);
-		setIsOpen(true);
-	};
-
 	return (
-		<div
-			ref={dropdownRef}
-			className={clsx(
-				"relative flex flex-col gap-[0.5rem]",
-				variant === "smallDropdown" &&
-					"w-[10.2rem] items-center md:w-[18rem] lg:w-[20rem]",
-			)}
+		<DropdownContext.Provider
+			value={{
+				isOpen,
+				setIsOpen,
+				placeholder,
+				selectedItem,
+				setSelectedItem,
+				onSelect,
+				setFilterQuery,
+				filteredItems,
+				setButtonVariant,
+				inputRef,
+				setInputRef,
+			}}
 		>
-			{variant === "dropdown" && (
-				<button
-					aria-haspopup="listbox"
-					aria-expanded={isOpen}
-					className={cn(
-						dropdownVariants({ variant }),
-						isOpen && "outline-[#5097FA]",
-					)}
-					onClick={() => setIsOpen(!isOpen)}
-					{...props}
-				>
-					<span className="text-[1.4rem] text-gray-200 lg:text-[1.6rem]">
-						{selectedItem ? selectedItem.name : placeholder}
-					</span>
-					<motion.div
-						animate={isOpen ? "open" : "close"}
-						variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
-					>
-						<Image
-							src={dropdownIcon}
-							alt="드랍다운 아이콘"
-							width={30}
-							height={30}
-						/>
-					</motion.div>
-				</button>
-			)}
-			{variant === "smallDropdown" && (
-				<button
-					aria-haspopup="listbox"
-					aria-expanded={isOpen}
-					className={cn(dropdownVariants({ variant }))}
-					onClick={() => setIsOpen(!isOpen)}
-					{...props}
-				>
-					<span
-						className={clsx(
-							"text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
-							isOpen && "text-white",
-						)}
-					>
-						{selectedItem ? selectedItem.name : items[0].name}
-					</span>
-					<motion.div
-						animate={isOpen ? "open" : "close"}
-						variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
-					>
-						<Image
-							src={dropdownIcon}
-							alt="드랍다운 아이콘"
-							width={30}
-							height={30}
-						/>
-					</motion.div>
-				</button>
-			)}
-			{variant === "filteredDropdown" && (
-				<input
-					type="text"
-					aria-haspopup="listbox"
-					aria-label="드롭다운 아이템 필터링"
-					ref={inputRef}
-					className={cn(dropdownVariants({ variant }))}
-					placeholder={placeholder}
-					onChange={handleChange}
-					{...props}
-				/>
-			)}
-			{(variant !== "filteredDropdown" ||
-				(filterQuery && filteredItems.length !== 0)) && (
-				<motion.ul
-					role="listbox"
-					animate={isOpen ? "open" : "close"}
-					variants={{
-						open: {
-							opacity: 1,
-						},
-						close: { opacity: 0 },
-					}}
-					transition={{ duration: 0.1 }}
-					style={{ pointerEvents: isOpen ? "auto" : "none" }}
-					className="absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]"
-				>
-					{filteredItems?.map((item) => (
-						<li
-							role="option"
-							aria-selected={selectedItem?.id === item.id}
-							key={item.id}
-						>
-							<button
-								onClick={() => handleSelectItem(item)}
-								className="w-full rounded-[0.6rem] px-[2rem] py-[0.6rem] text-left text-gray-200 hover:bg-[#353542] hover:text-white"
-							>
-								<span className="text-[1.4rem] lg:text-[1.6rem]">
-									{item.name}
-								</span>
-							</button>
-						</li>
-					))}
-				</motion.ul>
-			)}
-		</div>
+			<div
+				ref={dropdownRef}
+				className={clsx(
+					"relative flex flex-col gap-[0.5rem]",
+					buttonVariant === "small" &&
+						"w-[10.2rem] items-center md:w-[18rem] lg:w-[20rem]",
+				)}
+			>
+				{children}
+			</div>
+		</DropdownContext.Provider>
 	);
 }
+
+Dropdown.Button = DropdownToggleButton;
+Dropdown.Input = DropdownFilterInput;
+Dropdown.List = DropdownList;

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -5,6 +5,7 @@ import {
 	ReactNode,
 	RefObject,
 	SetStateAction,
+	useMemo,
 	useState,
 } from "react";
 
@@ -22,7 +23,7 @@ export type Item = {
 type DropdownContextType<T extends Item> = {
 	isOpen: boolean;
 	setIsOpen: Dispatch<SetStateAction<boolean>>;
-	placeholder: string;
+	placeholder: string | undefined;
 	selectedItem: T | null;
 	setSelectedItem: Dispatch<SetStateAction<T | null>>;
 	onSelect: (item: T) => void;
@@ -37,7 +38,8 @@ export const DropdownContext = createContext<DropdownContextType<any>>(null!);
 
 type Props<T extends Item> = {
 	items: T[];
-	placeholder: string;
+	defaultItem?: T;
+	placeholder?: string;
 	onSelect: (item: T) => void;
 	children: ReactNode;
 };
@@ -45,20 +47,27 @@ type Props<T extends Item> = {
 export default function Dropdown<T extends Item>({
 	placeholder,
 	items,
+	defaultItem,
 	onSelect,
 	children,
 }: Props<T>) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [filterQuery, setFilterQuery] = useState("");
-	const [selectedItem, setSelectedItem] = useState<T | null>(null);
+	const [selectedItem, setSelectedItem] = useState<T | null | undefined>(
+		defaultItem,
+	);
 	const [buttonVariant, setButtonVariant] = useState("");
 	const [inputRef, setInputRef] = useState<RefObject<HTMLInputElement> | null>(
 		null,
 	);
+	console.log("렌더링");
 
 	const dropdownRef = useOutsideClick<HTMLDivElement>(() => setIsOpen(false));
 
-	const filteredItems = items.filter((item) => item.name.includes(filterQuery));
+	const filteredItems = useMemo(
+		() => items.filter((item) => item.name.includes(filterQuery)),
+		[filterQuery, items],
+	);
 
 	return (
 		<DropdownContext.Provider

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -23,7 +23,6 @@ export type Item = {
 type DropdownContextType<T extends Item> = {
 	isOpen: boolean;
 	setIsOpen: Dispatch<SetStateAction<boolean>>;
-	placeholder: string | undefined;
 	selectedItem: T | null;
 	setSelectedItem: Dispatch<SetStateAction<T | null>>;
 	onSelect: (item: T) => void;
@@ -39,13 +38,11 @@ export const DropdownContext = createContext<DropdownContextType<any>>(null!);
 type Props<T extends Item> = {
 	items: T[];
 	defaultItem?: T;
-	placeholder?: string;
 	onSelect: (item: T) => void;
 	children: ReactNode;
 };
 
 export default function Dropdown<T extends Item>({
-	placeholder,
 	items,
 	defaultItem,
 	onSelect,
@@ -60,7 +57,6 @@ export default function Dropdown<T extends Item>({
 	const [inputRef, setInputRef] = useState<RefObject<HTMLInputElement> | null>(
 		null,
 	);
-	console.log("렌더링");
 
 	const dropdownRef = useOutsideClick<HTMLDivElement>(() => setIsOpen(false));
 
@@ -74,7 +70,6 @@ export default function Dropdown<T extends Item>({
 			value={{
 				isOpen,
 				setIsOpen,
-				placeholder,
 				selectedItem,
 				setSelectedItem,
 				onSelect,

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -24,7 +24,7 @@ const dropdownVariants = cva(
 					"bg-[#252530] px-[2rem] py-[1.25rem] outline outline-[#353542] md:py-[1.5rem] lg:py-[2rem]",
 				smallDropdown: "w-[6.2rem] md:w-[14rem] lg:w-[16rem]",
 				filteredDropdown:
-					"bg-[#252530] px-[2rem] py-[1.25rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.5rem] lg:py-[2rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
+					"bg-[#252530] px-[2rem] py-[1.7rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.95rem] lg:py-[2.3rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
 			},
 		},
 	},

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import {
 	createContext,
 	Dispatch,
@@ -10,6 +9,7 @@ import {
 } from "react";
 
 import useOutsideClick from "@/hooks/common/useOutsideClick";
+import cn from "@/utils/cn";
 
 import DropdownFilterInput from "./DropdownFilterInput";
 import DropdownList from "./DropdownList";
@@ -50,9 +50,7 @@ function Dropdown<T extends Item>({
 }: Props<T>) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [filterQuery, setFilterQuery] = useState("");
-	const [selectedItem, setSelectedItem] = useState<T | null | undefined>(
-		defaultItem,
-	);
+	const [selectedItem, setSelectedItem] = useState(defaultItem);
 	const [buttonVariant, setButtonVariant] = useState("");
 	const [inputRef, setInputRef] = useState<RefObject<HTMLInputElement> | null>(
 		null,
@@ -82,7 +80,7 @@ function Dropdown<T extends Item>({
 		>
 			<div
 				ref={dropdownRef}
-				className={clsx(
+				className={cn(
 					"relative flex flex-col gap-[0.5rem]",
 					buttonVariant === "small" &&
 						"w-[10.2rem] items-center md:w-[18rem] lg:w-[20rem]",

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,0 +1,185 @@
+import { cva, VariantProps } from "class-variance-authority";
+import clsx from "clsx";
+import { motion } from "framer-motion";
+import Image from "next/image";
+import { ChangeEvent, HTMLAttributes, useRef, useState } from "react";
+
+import useOutsideClick from "@/hooks/common/useOutsideClick";
+import cn from "@/utils/cn";
+
+type Props<T extends { id: number; name: string }> =
+	HTMLAttributes<HTMLElement> &
+		VariantProps<typeof dropdownVariants> & {
+			placeholder: string;
+			items: Array<T>;
+			onSelectItem: (item: T) => void;
+		};
+
+const dropdownVariants = cva(
+	"flex w-full items-center justify-between rounded-[0.8rem] ",
+	{
+		variants: {
+			variant: {
+				dropdown:
+					"bg-[#252530] px-[2rem] py-[1.25rem] outline outline-[#353542] md:py-[1.5rem] lg:py-[2rem]",
+				smallDropdown: "w-[6.2rem] md:w-[14rem] lg:w-[16rem]",
+				filteredDropdown:
+					"bg-[#252530] px-[2rem] py-[1.25rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.5rem] lg:py-[2rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
+			},
+		},
+	},
+);
+
+export default function Dropdown<T extends { id: number; name: string }>({
+	variant,
+	placeholder,
+	items,
+	onSelectItem,
+	...props
+}: Props<T>) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [selectedItem, setSelectedItem] = useState<T>();
+	const [filterQuery, setFilterQuery] = useState("");
+	const dropdownRef = useOutsideClick<HTMLDivElement>(() => setIsOpen(false));
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const filteredItems = items.filter((item) => item.name.includes(filterQuery));
+
+	const dropdownIcon = "/icons/drop_down.svg";
+
+	const handleSelectItem = (item: T) => {
+		setSelectedItem(item);
+		setIsOpen(false);
+		onSelectItem(item);
+
+		if (variant === "filteredDropdown" && inputRef.current) {
+			inputRef.current.value = item.name;
+		}
+	};
+
+	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+		const query = e.target.value;
+
+		if (!query.length) {
+			setFilterQuery(query);
+			setIsOpen(false);
+			return;
+		}
+
+		setFilterQuery(query);
+		setIsOpen(true);
+	};
+
+	return (
+		<div
+			ref={dropdownRef}
+			className={clsx(
+				"relative flex flex-col gap-[0.5rem]",
+				variant === "smallDropdown" &&
+					"w-[10.2rem] items-center md:w-[18rem] lg:w-[20rem]",
+			)}
+		>
+			{variant === "dropdown" && (
+				<button
+					aria-haspopup="listbox"
+					aria-expanded={isOpen}
+					className={cn(
+						dropdownVariants({ variant }),
+						isOpen && "outline-[#5097FA]",
+					)}
+					onClick={() => setIsOpen(!isOpen)}
+					{...props}
+				>
+					<span className="text-[1.4rem] text-gray-200 lg:text-[1.6rem]">
+						{selectedItem ? selectedItem.name : placeholder}
+					</span>
+					<motion.div
+						animate={isOpen ? "open" : "close"}
+						variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
+					>
+						<Image
+							src={dropdownIcon}
+							alt="드랍다운 아이콘"
+							width={30}
+							height={30}
+						/>
+					</motion.div>
+				</button>
+			)}
+			{variant === "smallDropdown" && (
+				<button
+					aria-haspopup="listbox"
+					aria-expanded={isOpen}
+					className={cn(dropdownVariants({ variant }))}
+					onClick={() => setIsOpen(!isOpen)}
+					{...props}
+				>
+					<span
+						className={clsx(
+							"text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
+							isOpen && "text-white",
+						)}
+					>
+						{selectedItem ? selectedItem.name : items[0].name}
+					</span>
+					<motion.div
+						animate={isOpen ? "open" : "close"}
+						variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
+					>
+						<Image
+							src={dropdownIcon}
+							alt="드랍다운 아이콘"
+							width={30}
+							height={30}
+						/>
+					</motion.div>
+				</button>
+			)}
+			{variant === "filteredDropdown" && (
+				<input
+					type="text"
+					aria-haspopup="listbox"
+					aria-label="드롭다운 아이템 필터링"
+					ref={inputRef}
+					className={cn(dropdownVariants({ variant }))}
+					placeholder={placeholder}
+					onChange={handleChange}
+					{...props}
+				/>
+			)}
+			{(variant !== "filteredDropdown" ||
+				(filterQuery && filteredItems.length !== 0)) && (
+				<motion.ul
+					role="listbox"
+					animate={isOpen ? "open" : "close"}
+					variants={{
+						open: {
+							opacity: 1,
+						},
+						close: { opacity: 0 },
+					}}
+					transition={{ duration: 0.1 }}
+					style={{ pointerEvents: isOpen ? "auto" : "none" }}
+					className="absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]"
+				>
+					{filteredItems?.map((item) => (
+						<li
+							role="option"
+							aria-selected={selectedItem?.id === item.id}
+							key={item.id}
+						>
+							<button
+								onClick={() => handleSelectItem(item)}
+								className="w-full rounded-[0.6rem] px-[2rem] py-[0.6rem] text-left text-gray-200 hover:bg-[#353542] hover:text-white"
+							>
+								<span className="text-[1.4rem] lg:text-[1.6rem]">
+									{item.name}
+								</span>
+							</button>
+						</li>
+					))}
+				</motion.ul>
+			)}
+		</div>
+	);
+}

--- a/src/components/common/dropdown/DropdownFilterInput.tsx
+++ b/src/components/common/dropdown/DropdownFilterInput.tsx
@@ -30,7 +30,7 @@ export default function DropdownFilterInput({
 	variant,
 	...props
 }: DropdownFilterProps) {
-	const { setIsOpen, setFilterQuery, placeholder, setInputRef } =
+	const { setIsOpen, setFilterQuery, setInputRef } =
 		useContext(DropdownContext);
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -50,7 +50,6 @@ export default function DropdownFilterInput({
 				aria-label="드롭다운 아이템 필터링"
 				ref={inputRef}
 				className={cn(dropdownFilterVariants({ variant }))}
-				placeholder={placeholder}
 				onChange={handleChange}
 				onFocus={() => setIsOpen(true)}
 				{...props}

--- a/src/components/common/dropdown/DropdownFilterInput.tsx
+++ b/src/components/common/dropdown/DropdownFilterInput.tsx
@@ -1,0 +1,60 @@
+import { cva, VariantProps } from "class-variance-authority";
+import {
+	ChangeEvent,
+	InputHTMLAttributes,
+	useContext,
+	useEffect,
+	useRef,
+} from "react";
+
+import cn from "@/utils/cn";
+
+import { DropdownContext } from "./Dropdown";
+
+type DropdownFilterProps = InputHTMLAttributes<HTMLInputElement> &
+	VariantProps<typeof dropdownFilterVariants>;
+
+const dropdownFilterVariants = cva(
+	"flex w-full items-center justify-between rounded-[0.8rem] bg-[#252530] px-[2rem] py-[1.7rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.95rem] lg:py-[2.3rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
+	{
+		variants: {
+			variant: {
+				normal: "",
+				withChip: "",
+			},
+		},
+	},
+);
+
+export default function DropdownFilterInput({
+	variant,
+	...props
+}: DropdownFilterProps) {
+	const { setIsOpen, setFilterQuery, placeholder, setInputRef } =
+		useContext(DropdownContext);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+		setFilterQuery(e.target.value);
+	};
+
+	useEffect(() => {
+		setInputRef(inputRef);
+	}, [setInputRef]);
+
+	return (
+		<div>
+			<input
+				type="text"
+				aria-haspopup="listbox"
+				aria-label="드롭다운 아이템 필터링"
+				ref={inputRef}
+				className={cn(dropdownFilterVariants({ variant }))}
+				placeholder={placeholder}
+				onChange={handleChange}
+				onFocus={() => setIsOpen(true)}
+				{...props}
+			/>
+		</div>
+	);
+}

--- a/src/components/common/dropdown/DropdownList.tsx
+++ b/src/components/common/dropdown/DropdownList.tsx
@@ -1,0 +1,62 @@
+import { motion } from "framer-motion";
+import { useContext } from "react";
+
+import { DropdownContext, Item } from "./Dropdown";
+
+export default function DropdownList<T extends Item>() {
+	const {
+		isOpen,
+		filteredItems,
+		selectedItem,
+		setSelectedItem,
+		setIsOpen,
+		onSelect,
+		inputRef,
+	} = useContext(DropdownContext);
+
+	const handleSelectItem = (item: T) => {
+		setSelectedItem(item);
+		setIsOpen(false);
+		onSelect(item);
+
+		if (inputRef && inputRef.current) {
+			inputRef.current.value = item.name;
+		}
+	};
+
+	if (filteredItems.length === 0) {
+		return null;
+	}
+
+	return (
+		<motion.ul
+			role="listbox"
+			animate={isOpen ? "open" : "close"}
+			initial="close"
+			variants={{
+				open: {
+					opacity: 1,
+				},
+				close: { opacity: 0 },
+			}}
+			transition={{ duration: 0.1 }}
+			style={{ pointerEvents: isOpen ? "auto" : "none" }}
+			className="absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]"
+		>
+			{filteredItems?.map((item) => (
+				<li
+					role="option"
+					aria-selected={selectedItem?.id === item.id}
+					key={item.id}
+				>
+					<button
+						onClick={() => handleSelectItem(item)}
+						className="w-full rounded-[0.6rem] px-[2rem] py-[0.6rem] text-left text-gray-200 hover:bg-[#353542] hover:text-white"
+					>
+						<span className="text-[1.4rem] lg:text-[1.6rem]">{item.name}</span>
+					</button>
+				</li>
+			))}
+		</motion.ul>
+	);
+}

--- a/src/components/common/dropdown/DropdownToggleButton.tsx
+++ b/src/components/common/dropdown/DropdownToggleButton.tsx
@@ -1,0 +1,71 @@
+import { cva, VariantProps } from "class-variance-authority";
+import clsx from "clsx";
+import { motion } from "framer-motion";
+import Image from "next/image";
+import { ButtonHTMLAttributes, useContext, useEffect } from "react";
+
+import cn from "@/utils/cn";
+
+import { DropdownContext } from "./Dropdown";
+
+type DropdownButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+	VariantProps<typeof dropdownButtonVariants>;
+
+const dropdownButtonVariants = cva(
+	"flex w-full items-center justify-between rounded-[0.8rem]",
+	{
+		variants: {
+			variant: {
+				basic:
+					"bg-[#252530] px-[2rem] py-[1.25rem] outline outline-[#353542] md:py-[1.5rem] lg:py-[2rem]",
+				small: "w-[6.2rem] md:w-[14rem] lg:w-[16rem]",
+			},
+		},
+	},
+);
+
+export default function DropdownToggleButton({
+	variant = "basic",
+	...props
+}: DropdownButtonProps) {
+	const { isOpen, setIsOpen, selectedItem, placeholder, setButtonVariant } =
+		useContext(DropdownContext);
+	const dropdownIcon = "/icons/drop_down.svg";
+
+	useEffect(() => {
+		setButtonVariant(variant as string);
+	}, [setButtonVariant, variant]);
+
+	return (
+		<button
+			aria-haspopup="listbox"
+			aria-expanded={isOpen}
+			className={cn(
+				dropdownButtonVariants({ variant }),
+				isOpen && "outline-[#5097FA]",
+			)}
+			onClick={() => setIsOpen(!isOpen)}
+			{...props}
+		>
+			<span
+				className={clsx(
+					"text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
+					variant === "small" && isOpen && "text-white",
+				)}
+			>
+				{selectedItem ? selectedItem.name : placeholder}
+			</span>
+			<motion.div
+				animate={isOpen ? "open" : "close"}
+				variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
+			>
+				<Image
+					src={dropdownIcon}
+					alt="드랍다운 아이콘"
+					width={30}
+					height={30}
+				/>
+			</motion.div>
+		</button>
+	);
+}

--- a/src/components/common/dropdown/DropdownToggleButton.tsx
+++ b/src/components/common/dropdown/DropdownToggleButton.tsx
@@ -1,5 +1,4 @@
 import { cva, VariantProps } from "class-variance-authority";
-import clsx from "clsx";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import { ButtonHTMLAttributes, useContext, useEffect } from "react";
@@ -31,7 +30,7 @@ export default function DropdownToggleButton({
 }: DropdownButtonProps) {
 	const { isOpen, setIsOpen, selectedItem, setButtonVariant } =
 		useContext(DropdownContext);
-	const dropdownIcon = "/icons/drop_down.svg";
+	const dropdownIconSrc = "/icons/drop_down.svg";
 
 	useEffect(() => {
 		setButtonVariant(variant as string);
@@ -49,7 +48,7 @@ export default function DropdownToggleButton({
 			{...props}
 		>
 			<span
-				className={clsx(
+				className={cn(
 					"text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
 					variant === "small" && isOpen && "text-white",
 				)}
@@ -61,10 +60,10 @@ export default function DropdownToggleButton({
 				variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
 			>
 				<Image
-					src={dropdownIcon}
+					src={dropdownIconSrc}
 					alt="드랍다운 아이콘"
-					width={30}
-					height={30}
+					width={24}
+					height={24}
 				/>
 			</motion.div>
 		</button>

--- a/src/components/common/dropdown/DropdownToggleButton.tsx
+++ b/src/components/common/dropdown/DropdownToggleButton.tsx
@@ -9,7 +9,7 @@ import cn from "@/utils/cn";
 import { DropdownContext } from "./Dropdown";
 
 type DropdownButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
-	VariantProps<typeof dropdownButtonVariants>;
+	VariantProps<typeof dropdownButtonVariants> & { placeholder?: string };
 
 const dropdownButtonVariants = cva(
 	"flex w-full items-center justify-between rounded-[0.8rem]",
@@ -26,9 +26,10 @@ const dropdownButtonVariants = cva(
 
 export default function DropdownToggleButton({
 	variant = "basic",
+	placeholder,
 	...props
 }: DropdownButtonProps) {
-	const { isOpen, setIsOpen, selectedItem, placeholder, setButtonVariant } =
+	const { isOpen, setIsOpen, selectedItem, setButtonVariant } =
 		useContext(DropdownContext);
 	const dropdownIcon = "/icons/drop_down.svg";
 

--- a/src/hooks/common/useOutsideClick.ts
+++ b/src/hooks/common/useOutsideClick.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+
+export default function useOutsideClick<T extends HTMLElement>(
+	callback: () => void,
+) {
+	const ref = useRef<T>(null);
+
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (ref.current && !ref.current.contains(event.target as Node)) {
+				callback();
+			}
+		};
+
+		document.addEventListener("mousedown", handleClickOutside);
+
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [callback]);
+
+	return ref;
+}

--- a/src/stories/Dropdown.stories.ts
+++ b/src/stories/Dropdown.stories.ts
@@ -1,0 +1,113 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+
+import Dropdown from "@/components/common/dropdown/Dropdown";
+
+const meta = {
+	title: "Components/Common/Dropdown",
+	component: Dropdown,
+	tags: ["autodocs"],
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+const categories = [
+	{
+		id: 1,
+		name: "음악",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 2,
+		name: "영화/드라마",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 3,
+		name: "강의/책",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 4,
+		name: "호텔",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 5,
+		name: "가구/인테리어",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 6,
+		name: "식당",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 7,
+		name: "전자기기",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 8,
+		name: "화장품",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 9,
+		name: "의류/잡화",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+	{
+		id: 10,
+		name: "앱",
+		createdAt: "2024-01-29T09:08:53.506Z",
+		updatedAt: "2024-01-29T09:08:53.506Z",
+	},
+];
+
+const filterBy = [
+	{
+		id: 0,
+		name: "최신순",
+	},
+	{
+		id: 1,
+		name: "별점 높은순",
+	},
+	{
+		id: 2,
+		name: "좋아요순",
+	},
+];
+
+export const BasicDropdown: StoryObj<typeof Dropdown> = {
+	args: {
+		variant: "dropdown",
+		placeholder: "카테고리 선택",
+		items: categories,
+	},
+};
+
+export const SmallDropdown: StoryObj<typeof Dropdown> = {
+	args: {
+		variant: "smallDropdown",
+		items: filterBy,
+	},
+};
+
+export const FilteredDropdown: StoryObj<typeof Dropdown> = {
+	args: {
+		variant: "filteredDropdown",
+		placeholder: "카테고리 선택",
+		items: categories,
+	},
+};

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -91,23 +91,41 @@ const filterBy = [
 
 export const BasicDropdown: StoryObj<typeof Dropdown> = {
 	args: {
-		variant: "dropdown",
 		placeholder: "카테고리 선택",
 		items: categories,
+		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
+		children: (
+			<>
+				<Dropdown.Button variant={"basic"} />
+				<Dropdown.List />
+			</>
+		),
 	},
 };
 
 export const SmallDropdown: StoryObj<typeof Dropdown> = {
 	args: {
-		variant: "smallDropdown",
 		items: filterBy,
+		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
+		children: (
+			<>
+				<Dropdown.Button variant={"small"} />
+				<Dropdown.List />
+			</>
+		),
 	},
 };
 
 export const FilteredDropdown: StoryObj<typeof Dropdown> = {
 	args: {
-		variant: "filteredDropdown",
 		placeholder: "카테고리 선택",
 		items: categories,
+		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
+		children: (
+			<>
+				<Dropdown.Input />
+				<Dropdown.List />
+			</>
+		),
 	},
 };

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -91,12 +91,11 @@ const filterBy = [
 
 export const BasicDropdown: StoryObj<typeof Dropdown> = {
 	args: {
-		placeholder: "카테고리 선택",
 		items: categories,
 		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
 		children: (
 			<>
-				<Dropdown.Button variant={"basic"} />
+				<Dropdown.Button variant={"basic"} placeholder="카테고리 선택" />
 				<Dropdown.List />
 			</>
 		),
@@ -106,6 +105,7 @@ export const BasicDropdown: StoryObj<typeof Dropdown> = {
 export const SmallDropdown: StoryObj<typeof Dropdown> = {
 	args: {
 		items: filterBy,
+		defaultItem: filterBy[0],
 		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
 		children: (
 			<>
@@ -118,12 +118,11 @@ export const SmallDropdown: StoryObj<typeof Dropdown> = {
 
 export const FilteredDropdown: StoryObj<typeof Dropdown> = {
 	args: {
-		placeholder: "카테고리 선택",
 		items: categories,
 		onSelect: (item) => console.log(`선택된 항목: ${item.name}`),
 		children: (
 			<>
-				<Dropdown.Input />
+				<Dropdown.Input placeholder="카테고리 선택" />
 				<Dropdown.List />
 			</>
 		),

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,6 @@
+type Category = {
+	updatedAt: string;
+	createdAt: string;
+	name: string;
+	id: number;
+};


### PR DESCRIPTION
Close #25

### 📌 작업 사항
---

- [변경] BasicButton 컴포넌트
- [구현] Dropdown 컴포넌트
- [구현] useOutsideClick 훅

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)
---

- 시안 상 input에 dropdown을 넣어야 하는 경우가 있어 거기까지 구현해야하나 고민됐지만 일단 했습니다.
- 키보드 방향키로 옵션을 선택하는 기능을 추가해야할 필요가 있어 보입니다.

- <img width="302" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/1365c564-ebee-485a-8049-29a3db82965a"> 얘는 어떻게 해야하나 고민되는군요.. 😢 
- ~컴포넌트를 나눠야하나 고민이 됩니다. filteredDropdown 을 아예 따로 뺄지, DropdownList 등으로 옵션들이 표현되는 ul 태그 이하를 나눌지 고민되는데 의견 주세요!~
- 채연님 리뷰 이후 각각의 컴포넌트로 나눠 컴파운드 패턴으로 만들어봤습니다... 다 말 못할 지옥의 수정 끝에 얻은 건 결국 any로 퉁쳐지는 타입과 너무 많아서 오히려 가독성을 해치는 context value 들... 더 나아진게 맞는지 모르겠네요. 그냥 뇌절 같습니다ㅋㅋㅋ
- 스토리북은 올리긴 하는데 안됩니다.. 채연님이 강사님께 여쭤보셨던 이슈긴 한데 잠시 포기하고 일단 올립니다 죄송합니다 😢
- 컨텍스트 타입을 제네릭으로 안전하게 사용하는 방법, 상태 갯수를 줄일 수 있는 방법, context 를 어떻게 분리하면 좋을지 알려주시면 감사하겠습니다!

### 📌 사용 방법 (선택)
---

- ~variant 는 총 3개로 각각 dropdown(일반 드롭다운), smallDropdown(작은 드롭다운..), filteredDropdown(input에 넣는 결과가 드롭다운 됨) 입니다.~
- ~smallDropdown 는 고정 너비, 나머지는 꽉 차게 구현돼 있습니다.~
- ~onSelectItem prop으로 선택한 아이템을 넘겨줍니다.~
- ~category와 product 모두 id 와 name을 갖고 있어 id와 name이 있는 객체의 배열만이 들어갈 수 있도록 구현했습니다.~

1. button으로 제어 되는 드롭다운
2. input에 입력되는 값으로 필터링 되는 드롭다운

두 가지 패턴으로 사용할 수 있습니다.

버튼의 경우 Dropdown.Button에 variant로 "basic" 과 "small"을 사용할 수 있습니다.


```tsx
// button으로 제어 되는 드롭다운
// 기본값 x
<Dropdown
  items={data} 
  onSelect={(item) => console.log(item)}
>
  <Dropdown.Button placeholder={"카테고리 선택"} variant={"basic"} />
  <Dropdown.List />
</Dropdown>

// 기본값 o
<Dropdown
  items={filterBy}
  onSelect={(item) => console.log(item)}
  defaultItem={filterBy[0]}
>
  <Dropdown.Button variant={"small"} />
  <Dropdown.List />
</Dropdown>
```

```tsx
// input에 입력되는 값으로 필터링 되는 드롭다운
<Dropdown items={data || []} onSelect={(item) => console.log(item)}>
  <Dropdown.Input placeholder="카테고리 선택" />
  <Dropdown.List />
</Dropdown>
```

### 📌 스크린샷 / 테스트결과 (선택)
---
#### 기본 버튼 드롭다운
<img width="414" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/eb0a6e17-f4ea-44dc-8e64-8b23779f534e">
<img width="426" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/ebaadd46-c353-49ee-803c-334ac450ef78">
<img width="428" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/b4f5bf8d-6e97-4364-98a4-20034eb0d461">

#### 작은 버튼 드롭다운
<img width="192" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/56237179-4692-4aa1-8fa9-e741a3155d08">
<img width="217" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/22b00f3d-72e6-4875-b59b-6afa88c382a1">
<img width="194" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/74b32948-250b-446c-8d5e-ffbf1111416a">


#### 인풋 필터 드롭다운
<img width="425" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/f5952128-3678-442b-a6ea-ab29c9018df8">
<img width="423" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/1f95f0c2-5e01-4674-9b73-41840ecbbb24">
<img width="422" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/08491f2b-848a-44cd-9a85-5a5f8320ae24">

