### PR TITLE
chore: 프로필 기본 이미지 설정

### DIFF
--- a/src/components/common/followerProfile/FollowerProfile.tsx
+++ b/src/components/common/followerProfile/FollowerProfile.tsx
@@ -2,7 +2,7 @@ import Nickname from "../nickname/Nickname";
 import ProfileImage from "../profileImage/ProfileImage";
 
 type Props = {
-	image: string;
+	image: null | string;
 	nickname: string;
 };
 

--- a/src/components/common/profileImage/ProfileImage.tsx
+++ b/src/components/common/profileImage/ProfileImage.tsx
@@ -14,17 +14,18 @@ const profileImageVariants = cva("relative overflow-hidden rounded-full", {
 	},
 });
 
-// todo: StaticImageData 타입은 추후 기능 구현 테스트 이후에 삭제 예정
 type Props = React.HTMLAttributes<HTMLDivElement> &
 	VariantProps<typeof profileImageVariants> & {
 		size: "small" | "medium" | "large";
-		src: string | StaticImageData;
+		src: null | string;
 	};
 
 export default function ProfileImage({ src, size }: Props) {
+	const iconSrc = src ? src : "/icons/profile.svg";
+
 	return (
 		<div className={cn(profileImageVariants({ size }))}>
-			<Image src={src} alt="사용자 프로필 이미지" fill />
+			<Image src={iconSrc} alt="사용자 프로필 이미지" fill />
 		</div>
 	);
 }

--- a/src/components/common/reviewerProfile/ReviewerProfile.tsx
+++ b/src/components/common/reviewerProfile/ReviewerProfile.tsx
@@ -4,7 +4,7 @@ import ProfileImage from "../profileImage/ProfileImage";
 import Ranking from "../ranking/Ranking";
 
 type ReviewerData = {
-	image: string;
+	image: null | string;
 	rank: number;
 	nickname: string;
 	followersCount: number;

--- a/src/stories/FollowerProfile.stories.ts
+++ b/src/stories/FollowerProfile.stories.ts
@@ -20,3 +20,10 @@ export const Default: Story = {
 		nickname: "리뷰왕",
 	},
 };
+
+export const NoImage: Story = {
+	args: {
+		image: null,
+		nickname: "리뷰왕",
+	},
+};

--- a/src/stories/ReviewerProfile.stories.ts
+++ b/src/stories/ReviewerProfile.stories.ts
@@ -25,3 +25,15 @@ export const Default: Story = {
 		},
 	},
 };
+
+export const NoImage: Story = {
+	args: {
+		reviewerData: {
+			image: null,
+			rank: 1,
+			nickname: "리뷰왕",
+			followersCount: 123,
+			reviewCount: 456,
+		},
+	},
+};


### PR DESCRIPTION
### 📌 작업 사항

---

- 프로필에 등록된 이미지가 없을 때 보여줄 기본 이미지 설정

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 이미 public 파일에 추가되어있던 아이콘(svg)이 있길래 그걸 넣어봤는데, 회의 때 우현님이 보여주셨던 이미지가 더 좋을까요?

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
<img width="184" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/141597336/71c19284-d020-4fc9-9d75-945f059d2ad5">

