### PR TITLE
feat:프로필 페이지 UI

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,19 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+	reactStrictMode: true,
+	images: {
+		// TODO: 추후 우리팀 api url
+		remotePatterns: [
+			{
+				protocol: "http",
+				hostname: "**",
+			},
+			{
+				protocol: "https",
+				hostname: "**",
+			},
+		],
+	},
 };
 
 export default nextConfig;

--- a/src/components/common/activitycard/ActivityCard.tsx
+++ b/src/components/common/activitycard/ActivityCard.tsx
@@ -57,7 +57,7 @@ export default function ActivityCard({
 	const { label, img, data } = DataList[type];
 
 	return (
-		<div className="flex h-[11.9rem] w-[10.5rem] flex-col items-center justify-center gap-[1.5rem] rounded-[1.2rem] border border-[#353542] bg-[#252530] md:w-[16.3rem] lg:h-[12.8rem] lg:w-[30rem] lg:gap-[2rem]">
+		<div className="flex h-[11.9rem] max-w-[10.5rem] grow flex-col items-center justify-center gap-[1.5rem] rounded-[1.2rem] border border-[#353542] bg-[#252530] md:max-w-[16.3rem] lg:h-[12.8rem] lg:max-w-[30rem] lg:gap-[2rem]">
 			<div className="hidden text-[1.4rem] text-gray-100 md:flex lg:text-[1.6rem]">
 				{label.join(" ")}
 			</div>

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -40,6 +40,7 @@ type Props<T extends Item> = {
 	defaultItem?: T;
 	onSelect: (item: T) => void;
 	children: ReactNode;
+	className?: string;
 };
 
 function Dropdown<T extends Item>({
@@ -47,6 +48,7 @@ function Dropdown<T extends Item>({
 	defaultItem,
 	onSelect,
 	children,
+	className,
 }: Props<T>) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [filterQuery, setFilterQuery] = useState("");
@@ -84,6 +86,7 @@ function Dropdown<T extends Item>({
 					"relative flex flex-col gap-[0.5rem]",
 					buttonVariant === "small" &&
 						"w-[12rem] items-center md:w-[18rem] lg:w-[20rem]",
+					className,
 				)}
 			>
 				{children}

--- a/src/components/common/dropdown/DropdownFilterInput.tsx
+++ b/src/components/common/dropdown/DropdownFilterInput.tsx
@@ -12,7 +12,7 @@ import cn from "@/utils/cn";
 import { DropdownContext } from "./Dropdown";
 
 type DropdownFilterProps = InputHTMLAttributes<HTMLInputElement> &
-	VariantProps<typeof dropdownFilterVariants>;
+	VariantProps<typeof dropdownFilterVariants> & { className?: string };
 
 const dropdownFilterVariants = cva(
 	"flex w-full items-center justify-between rounded-[0.8rem] bg-[#252530] px-[2rem] py-[1.7rem] text-[1.4rem] text-white outline outline-[#353542] placeholder:text-[1.4rem] placeholder:text-gray-200 focus:outline-[#5097FA] md:py-[1.95rem] lg:py-[2.3rem] lg:text-[1.6rem] placeholder:lg:text-[1.6rem]",
@@ -28,6 +28,7 @@ const dropdownFilterVariants = cva(
 
 export default function DropdownFilterInput({
 	variant,
+	className,
 	...props
 }: DropdownFilterProps) {
 	const { setIsOpen, setFilterQuery, setInputRef } =
@@ -49,7 +50,7 @@ export default function DropdownFilterInput({
 				aria-haspopup="listbox"
 				aria-label="드롭다운 아이템 필터링"
 				ref={inputRef}
-				className={cn(dropdownFilterVariants({ variant }))}
+				className={cn(dropdownFilterVariants({ variant }), className)}
 				onChange={handleChange}
 				onFocus={() => setIsOpen(true)}
 				{...props}

--- a/src/components/common/dropdown/DropdownList.tsx
+++ b/src/components/common/dropdown/DropdownList.tsx
@@ -51,7 +51,7 @@ export default function DropdownList<T extends Item>({
 			transition={{ duration: 0.1 }}
 			style={{ pointerEvents: isOpen ? "auto" : "none" }}
 			className={cn(
-				"absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]",
+				"z-10 absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]",
 				className,
 			)}
 			{...props}

--- a/src/components/common/dropdown/DropdownList.tsx
+++ b/src/components/common/dropdown/DropdownList.tsx
@@ -1,9 +1,18 @@
-import { motion } from "framer-motion";
+import { HTMLMotionProps, motion } from "framer-motion";
 import { useContext } from "react";
+
+import cn from "@/utils/cn";
 
 import { DropdownContext, Item } from "./Dropdown";
 
-export default function DropdownList<T extends Item>() {
+type Props = HTMLMotionProps<"ul"> & {
+	className?: string;
+};
+
+export default function DropdownList<T extends Item>({
+	className,
+	...props
+}: Props) {
 	const {
 		isOpen,
 		filteredItems,
@@ -41,7 +50,11 @@ export default function DropdownList<T extends Item>() {
 			}}
 			transition={{ duration: 0.1 }}
 			style={{ pointerEvents: isOpen ? "auto" : "none" }}
-			className="absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]"
+			className={cn(
+				"absolute top-[100%] mt-[0.6rem] flex w-full flex-col gap-[0.5rem] rounded-[0.8rem] bg-[#252530] p-[1rem] outline outline-[#353542]",
+				className,
+			)}
+			{...props}
 		>
 			{filteredItems?.map((item) => (
 				<li

--- a/src/components/common/dropdown/DropdownToggleButton.tsx
+++ b/src/components/common/dropdown/DropdownToggleButton.tsx
@@ -8,10 +8,13 @@ import cn from "@/utils/cn";
 import { DropdownContext } from "./Dropdown";
 
 type DropdownButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
-	VariantProps<typeof dropdownButtonVariants> & { placeholder?: string };
+	VariantProps<typeof dropdownButtonVariants> & {
+		placeholder?: string;
+		className?: string;
+	};
 
 const dropdownButtonVariants = cva(
-	"flex w-full items-center justify-between rounded-[0.8rem]",
+	"flex w-full items-center justify-between rounded-[0.8rem] text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
 	{
 		variants: {
 			variant: {
@@ -26,6 +29,7 @@ const dropdownButtonVariants = cva(
 export default function DropdownToggleButton({
 	variant = "basic",
 	placeholder,
+	className,
 	...props
 }: DropdownButtonProps) {
 	const { isOpen, setIsOpen, selectedItem, setButtonVariant } =
@@ -42,17 +46,13 @@ export default function DropdownToggleButton({
 			aria-expanded={isOpen}
 			className={cn(
 				dropdownButtonVariants({ variant }),
+				className,
 				isOpen && "outline-[#5097FA]",
 			)}
 			onClick={() => setIsOpen(!isOpen)}
 			{...props}
 		>
-			<span
-				className={cn(
-					"text-[1.4rem] text-gray-200 lg:text-[1.6rem]",
-					variant === "small" && isOpen && "text-white",
-				)}
-			>
+			<span className={cn(variant === "small" && isOpen && "text-white")}>
 				{selectedItem ? selectedItem.name : placeholder}
 			</span>
 			<motion.div

--- a/src/components/common/dropdown/DropdownToggleButton.tsx
+++ b/src/components/common/dropdown/DropdownToggleButton.tsx
@@ -55,7 +55,7 @@ export default function DropdownToggleButton({
 			<span className={cn(variant === "small" && isOpen && "text-white")}>
 				{selectedItem ? selectedItem.name : placeholder}
 			</span>
-			<motion.div
+			<motion.span
 				animate={isOpen ? "open" : "close"}
 				variants={{ open: { rotate: 180 }, close: { rotate: 0 } }}
 			>
@@ -65,7 +65,7 @@ export default function DropdownToggleButton({
 					width={24}
 					height={24}
 				/>
-			</motion.div>
+			</motion.span>
 		</button>
 	);
 }

--- a/src/components/common/productcard/ProductCard.tsx
+++ b/src/components/common/productcard/ProductCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-import Counts from "../counts/Counts";
+import Counts from "@/components/common/counts/Counts";
 
 type Props = {
 	productName: string;
@@ -19,8 +19,8 @@ export default function ProductCard({
 }: Props) {
 	const starIconSrc = "/icons/star.svg";
 	return (
-		<div className="flex h-[18.3rem] w-[16rem] flex-col rounded-[1.2rem] border border-black-border bg-black-bg md:h-[25.6rem] md:w-[24.7rem] lg:h-[30.8rem] lg:w-[30rem]">
-			<div className="relative size-[14rem] md:size-[22.7rem] lg:size-[28.4rem]">
+		<div className="flex max-h-[18.3rem] max-w-[16rem] grow flex-col rounded-[1.2rem] border border-black-border bg-black-bg md:max-h-[25.6rem] md:max-w-[24.7rem] lg:max-h-[30.8rem] lg:max-w-[30rem]">
+			<div className="relative h-[14rem] max-w-[14rem] md:h-[22.7rem] md:max-w-[22.7rem] lg:h-[18.4rem] lg:max-w-[28.4rem]">
 				<Image
 					src={imageData}
 					alt={productName}

--- a/src/components/profile/ActivityDetails.tsx
+++ b/src/components/profile/ActivityDetails.tsx
@@ -1,0 +1,16 @@
+import ActivityCard from "@/components/common/activitycard/ActivityCard";
+
+export default function ActivityDetails() {
+	return (
+		<section className="flex flex-col gap-[3rem]">
+			<h2 className="text-[1.8rem] font-semibold text-white lg:text-[2rem]">
+				활동 내역
+			</h2>
+			<div className="flex gap-[1rem] lg:gap-[2rem]">
+				<ActivityCard myRateAvg={4.1} type="rate" />
+				<ActivityCard myReivewCount={125} type="review" />
+				<ActivityCard category={"전자기기"} type="category" />
+			</div>
+		</section>
+	);
+}

--- a/src/components/profile/FilteredProductList.tsx
+++ b/src/components/profile/FilteredProductList.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from "react";
+
+import Dropdown from "@/components/common/dropdown/Dropdown";
+import ProductCard from "@/components/common/productcard/ProductCard";
+import { breakPoint } from "@/constants/breakPoint";
+import useWindowWidth from "@/hooks/common/useWindowWidth";
+import cn from "@/utils/cn";
+
+const productsFilter = [
+	{
+		id: 0,
+		name: "리뷰 남긴 상품",
+		// func: getUserReviewedProducts,
+	},
+	{
+		id: 1,
+		name: "등록한 상품",
+		// func: getUserCreatedProducts,
+	},
+	{
+		id: 2,
+		name: "찜한 상품",
+		// func: getUserFavoriteProducts,
+	},
+];
+
+const products = [
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "e03eb43c-ef66-47d5-a9b8-13c75732c4c1",
+		categoryId: "b7d9f987-c081-4367-8cfe-5919a9178658",
+		favoriteCount: 4,
+		reviewCount: 34,
+		rating: 1.01,
+		image: "/images/sample.png",
+		name: "Eco-Friendly Water",
+		id: "13de02b2-00cb-4d0e-b533-12e66f3cb843",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "29357f52-c5d2-47e0-a562-fc282e517da0",
+		categoryId: "156f1aca-93c2-48c5-be99-a93bc223e852",
+		favoriteCount: 15,
+		reviewCount: 45,
+		rating: 4.97,
+		image: "/images/sample.png",
+		name: "Wireless Bluetooth Headphones",
+		id: "e23cc50c-6d17-4b97-a890-e37276e7f8fa",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "003d0145-376e-4057-9bfb-9be84048aed8",
+		categoryId: "00c02c64-fd88-4e03-8161-ed66dc1986bd",
+		favoriteCount: 30,
+		reviewCount: 26,
+		rating: 3.4,
+		image: "/images/sample.png",
+		name: "Organic Cotton T-Shirt",
+		id: "be89bdc1-6ab6-490e-9493-2dff3583247c",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "585d8124-0b0c-44c7-9a54-8b63ed84dc5e",
+		categoryId: "03ed98ae-7c61-44e1-8cc6-1b9bcf5ca300",
+		favoriteCount: 99,
+		reviewCount: 50,
+		rating: 1.85,
+		image: "/images/sample.png",
+		name: "Portable Solar Charger",
+		id: "d7652fc0-ec1d-4c87-8b58-7b16bd96eaed",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "fb821593-d622-42e8-97b1-3536a2144bfb",
+		categoryId: "446a341b-f48d-4cec-8bc1-ac0005ddb635",
+		favoriteCount: 100,
+		reviewCount: 0,
+		rating: 4.3,
+		image: "/images/sample.png",
+		name: "Smart Home Thermostat",
+		id: "6d7691d0-9c52-439f-8930-fe4a05f49112",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "b469d1dc-4141-47df-b333-0dc9587c193c",
+		categoryId: "ccb1ae94-1c84-442a-b4ee-adb8d796a597",
+		favoriteCount: 62,
+		reviewCount: 30,
+		rating: 1.21,
+		image: "/images/sample.png",
+		name: "Noise-Cancelling Earbuds",
+		id: "4d7857ce-fb31-44e4-aa1b-861eb30a138e",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "c5aa7916-4d47-47b3-b061-97ed4c8b2d25",
+		categoryId: "a4029d56-a853-4d2d-abf6-9748862f5447",
+		favoriteCount: 10,
+		reviewCount: 43,
+		rating: 4.53,
+		image: "/images/sample.png",
+		name: "Sustainable Bamboo Sunglasses",
+		id: "a11ee8fb-015b-4018-8fcc-8c2dd3dae57e",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "7acf32ea-01e7-4b38-88f7-d10b7a69378d",
+		categoryId: "483f1f74-35c7-43d2-afa4-66b2f3c7bb06",
+		favoriteCount: 27,
+		reviewCount: 48,
+		rating: 2.42,
+		image: "/images/sample.png",
+		name: "Ergonomic Office Chair",
+		id: "2c73e26a-4f65-4e8e-b51f-c7830982a2df",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "8c9e14f6-4cc0-43bf-9956-31e2cc9df010",
+		categoryId: "1af8057a-6fb7-4e56-99f6-67cd8b25b2c7",
+		favoriteCount: 53,
+		reviewCount: 46,
+		rating: 1.47,
+		image: "/images/sample.png",
+		name: "Compact Camping Tent",
+		id: "cf7e82bc-253e-4412-8964-838e3b622084",
+	},
+	{
+		updatedAt: "2024-03-13 06:30:20",
+		createdAt: "2024-03-13 06:30:20",
+		writerId: "2797731b-acba-45a9-ac5b-555a2c042818",
+		categoryId: "52aec8f5-fd56-4fbe-ad89-73240efe02f5",
+		favoriteCount: 81,
+		reviewCount: 32,
+		rating: 2.77,
+		image: "/images/sample.png",
+		name: "High-Speed USB Flash Drive",
+		id: "23344369-17f8-4dcf-835c-7681559e603a",
+	},
+];
+
+type ProductFilter = {
+	id: number;
+	name: string;
+	// func: () => void;
+};
+
+export default function FilteredProductList() {
+	const [currentFilter, setFilter] = useState<ProductFilter>(productsFilter[0]);
+	const [isLarge, setIsLarge] = useState(false);
+	const currentWidth = useWindowWidth();
+
+	const handleSelectFilter = (filter: ProductFilter) => {
+		setFilter(filter);
+	};
+
+	useEffect(() => {
+		setIsLarge(currentWidth >= breakPoint.lg);
+	}, [currentWidth]);
+
+	return (
+		<section className="flex flex-col gap-[3rem]">
+			<h2 className="sr-only">{currentFilter.name}</h2>
+			{isLarge ? (
+				<ul className="flex gap-[4rem]">
+					{productsFilter.map((filter) => (
+						<li key={filter.id}>
+							<button onClick={() => handleSelectFilter(filter)}>
+								<span
+									className={cn(
+										"text-[2rem] text-gray-200",
+										filter.id === currentFilter.id &&
+											"font-semibold text-white",
+									)}
+								>
+									{filter.name}
+								</span>
+							</button>
+						</li>
+					))}
+				</ul>
+			) : (
+				<Dropdown
+					items={productsFilter}
+					defaultItem={productsFilter[0]}
+					onSelect={handleSelectFilter}
+					className="w-[15rem]"
+				>
+					<Dropdown.Button
+						variant={"small"}
+						className="text-[1.8rem] font-semibold text-white lg:text-[2rem]"
+					/>
+					<Dropdown.List />
+				</Dropdown>
+			)}
+			<div className="grid grid-cols-2 gap-[1.5rem] lg:grid-cols-3 lg:gap-[2rem]">
+				{products.map((product) => (
+					<ProductCard
+						key={product.id}
+						imageData={product.image}
+						likeCount={product.favoriteCount}
+						productName={product.name}
+						rate={product.rating}
+						reviewCount={product.reviewCount}
+					/>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/src/components/profile/FilteredProductList.tsx
+++ b/src/components/profile/FilteredProductList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import Dropdown from "@/components/common/dropdown/Dropdown";
 import ProductCard from "@/components/common/productcard/ProductCard";
-import { breakPoint } from "@/constants/breakPoint";
+import { BREAK_POINT } from "@/constants/breakPoint";
 import useWindowWidth from "@/hooks/common/useWindowWidth";
 import cn from "@/utils/cn";
 
@@ -163,7 +163,7 @@ export default function FilteredProductList() {
 	};
 
 	useEffect(() => {
-		setIsLarge(currentWidth >= breakPoint.lg);
+		setIsLarge(currentWidth >= BREAK_POINT.lg);
 	}, [currentWidth]);
 
 	return (

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -1,7 +1,6 @@
+import BasicButton from "@/components/common/button/BasicButton";
+import ProfileImage from "@/components/common/profileImage/ProfileImage";
 import { UserDetail } from "@/types/user";
-
-import BasicButton from "../common/button/BasicButton";
-import ProfileImage from "../common/profileImage/ProfileImage";
 
 type Props = {
 	user: UserDetail;
@@ -10,16 +9,17 @@ type Props = {
 
 export default function ProfileCard({ user, isMine = true }: Props) {
 	return (
-		<div className="_flex-col-center w-[33.5rem] gap-[3rem] rounded-[1.2rem] border border-black-border bg-black-bg px-[2rem] py-[3rem] md:w-[50.9rem] lg:w-[34rem]">
+		<section className="_flex-col-center w-[33.5rem] gap-[3rem] rounded-[1.2rem] border border-black-border bg-black-bg px-[2rem] py-[3rem] md:w-[50.9rem] lg:w-[34rem]">
+			<h2 className="sr-only">기본 정보</h2>
 			<ProfileImage
 				size="large"
 				src={"https://github.com/pmndrs/zustand/raw/main/bear.jpg"}
 			/>
 			<div className="flex w-full flex-col gap-[1rem]">
-				<h1 className="self-center text-[2rem] font-semibold text-white">
+				<strong className="self-center text-[2rem] font-semibold text-white">
 					{user.nickname}
-				</h1>
-				<p className="max-w-[29.5rem] text-[1.4rem] text-gray-200">
+				</strong>
+				<p className="text-[1.4rem] text-gray-200">
 					세상에 리뷰 못할 제품은 없다. surisuri마수리와 함께라면 당신도
 					프로쇼핑러! 안녕하세요, 별점의 화신 surisuri마수리입니다!
 				</p>
@@ -40,7 +40,7 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 				</div>
 			</div>
 			{isMine ? (
-				<div className="_flex-col-center w-full gap-[1rem]">
+				<div className="_flex-col-center w-full gap-[1rem] md:gap-[1.5rem] lg:gap-[2rem]">
 					<BasicButton variant={"primary"} label="프로필 편집" />
 					<BasicButton variant={"tertiary"} label="로그아웃" />
 				</div>
@@ -50,6 +50,6 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 					variant={user.isFollowing ? "tertiary" : "primary"}
 				/>
 			)}
-		</div>
+		</section>
 	);
 }

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -19,10 +19,7 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 				<strong className="self-center text-[2rem] font-semibold text-white">
 					{user.nickname}
 				</strong>
-				<p className="text-[1.4rem] text-gray-200">
-					세상에 리뷰 못할 제품은 없다. surisuri마수리와 함께라면 당신도
-					프로쇼핑러! 안녕하세요, 별점의 화신 surisuri마수리입니다!
-				</p>
+				<p className="text-[1.4rem] text-gray-200">{user.description}</p>
 			</div>
 			<div className="flex w-full justify-evenly">
 				<div className="_flex-col-center">

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -1,0 +1,55 @@
+import { UserDetail } from "@/types/user";
+
+import BasicButton from "../common/button/BasicButton";
+import ProfileImage from "../common/profileImage/ProfileImage";
+
+type Props = {
+	user: UserDetail;
+	isMine: boolean;
+};
+
+export default function ProfileCard({ user, isMine = true }: Props) {
+	return (
+		<div className="_flex-col-center w-[33.5rem] gap-[3rem] rounded-[1.2rem] border border-black-border bg-black-bg px-[2rem] py-[3rem] md:w-[50.9rem] lg:w-[34rem]">
+			<ProfileImage
+				size="large"
+				src={"https://github.com/pmndrs/zustand/raw/main/bear.jpg"}
+			/>
+			<div className="flex w-full flex-col gap-[1rem]">
+				<h1 className="self-center text-[2rem] font-semibold text-white">
+					{user.nickname}
+				</h1>
+				<p className="max-w-[29.5rem] text-[1.4rem] text-gray-200">
+					세상에 리뷰 못할 제품은 없다. surisuri마수리와 함께라면 당신도
+					프로쇼핑러! 안녕하세요, 별점의 화신 surisuri마수리입니다!
+				</p>
+			</div>
+			<div className="flex w-full justify-evenly">
+				<div className="_flex-col-center">
+					<p className="text-[1.8rem] font-semibold text-white">
+						{user.followeesCount}
+					</p>
+					<p className="text-[1.4rem] text-gray-100">팔로워</p>
+				</div>
+				<div className="h-[4.8rem] w-[1px] bg-black-border"></div>
+				<div className="_flex-col-center">
+					<p className="text-[1.8rem] font-semibold text-white">
+						{user.followersCount}
+					</p>
+					<p className="text-[1.4rem] text-gray-100">팔로잉</p>
+				</div>
+			</div>
+			{isMine ? (
+				<div className="_flex-col-center w-full gap-[1rem]">
+					<BasicButton variant={"primary"} label="프로필 편집" />
+					<BasicButton variant={"tertiary"} label="로그아웃" />
+				</div>
+			) : (
+				<BasicButton
+					label={user.isFollowing ? "팔로우 취소" : "팔로우"}
+					variant={user.isFollowing ? "tertiary" : "primary"}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/components/profile/ProfilePageLayout.tsx
+++ b/src/components/profile/ProfilePageLayout.tsx
@@ -12,6 +12,8 @@ const dummyUser: UserDetail = {
 	updatedAt: "2024-03-12T12:00:00.000Z",
 	teamId: "team123",
 	nickname: "Froggy",
+	description:
+		"세상에 리뷰 못할 제품은 없다. surisuri마수리와 함께라면 당신도 프로쇼핑러! 안녕하세요, 별점의 화신 surisuri마수리입니다!",
 	image: "https://example.com/path/to/image.jpg",
 	followeesCount: 5,
 	followersCount: 8,

--- a/src/components/profile/ProfilePageLayout.tsx
+++ b/src/components/profile/ProfilePageLayout.tsx
@@ -1,5 +1,9 @@
+import { useRouter } from "next/router";
+
 import { UserDetail } from "@/types/user";
 
+import ActivityDetails from "./ActivityDetails";
+import FilteredProductList from "./FilteredProductList";
 import ProfileCard from "./ProfileCard";
 
 const dummyUser: UserDetail = {
@@ -14,10 +18,18 @@ const dummyUser: UserDetail = {
 	isFollowing: false,
 };
 
-export default function ProfilePageLayout({}) {
+export default function ProfilePageLayout() {
+	const router = useRouter();
+	const isMine = router.asPath.includes("my");
+
 	return (
-		<div className="_flex-col-center gap-[6rem] bg-[#1C1C22] px-[2rem] py-[3rem] lg:p-[6rem]">
-			<ProfileCard user={dummyUser} isMine={true} />
-		</div>
+		<main className="_flex-col-center gap-[6rem] bg-[#1C1C22] px-[2rem] py-[3rem] lg:flex-row lg:items-start lg:p-[6rem]">
+			<h1 className="sr-only">프로필 페이지</h1>
+			<ProfileCard user={dummyUser} isMine={isMine} />
+			<div className="flex flex-col gap-[6rem]">
+				<ActivityDetails />
+				<FilteredProductList />
+			</div>
+		</main>
 	);
 }

--- a/src/components/profile/ProfilePageLayout.tsx
+++ b/src/components/profile/ProfilePageLayout.tsx
@@ -1,0 +1,23 @@
+import { UserDetail } from "@/types/user";
+
+import ProfileCard from "./ProfileCard";
+
+const dummyUser: UserDetail = {
+	id: 1,
+	createdAt: "2024-03-12T09:00:00.000Z",
+	updatedAt: "2024-03-12T12:00:00.000Z",
+	teamId: "team123",
+	nickname: "Froggy",
+	image: "https://example.com/path/to/image.jpg",
+	followeesCount: 5,
+	followersCount: 8,
+	isFollowing: false,
+};
+
+export default function ProfilePageLayout({}) {
+	return (
+		<div className="_flex-col-center gap-[6rem] bg-[#1C1C22] px-[2rem] py-[3rem] lg:p-[6rem]">
+			<ProfileCard user={dummyUser} isMine={true} />
+		</div>
+	);
+}

--- a/src/constants/breakPoint.ts
+++ b/src/constants/breakPoint.ts
@@ -1,0 +1,4 @@
+export const breakPoint = {
+	md: 768,
+	lg: 1024,
+};

--- a/src/constants/breakPoint.ts
+++ b/src/constants/breakPoint.ts
@@ -1,4 +1,4 @@
-export const breakPoint = {
+export const BREAK_POINT = {
 	md: 768,
 	lg: 1024,
 };

--- a/src/hooks/common/useThrottle.ts
+++ b/src/hooks/common/useThrottle.ts
@@ -1,23 +1,32 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 function useThrottle<T extends (...args: any[]) => void>(
 	callback: T,
 	delay: number,
 ): T {
 	const isThrottling = useRef(false);
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const throttledCallback = useCallback(
 		(...args: any[]) => {
 			if (!isThrottling.current) {
 				callback(...args);
 				isThrottling.current = true;
-				setTimeout(() => {
+				timer.current = setTimeout(() => {
 					isThrottling.current = false;
 				}, delay);
 			}
 		},
 		[callback, delay],
 	);
+
+	useEffect(() => {
+		return () => {
+			if (timer.current) {
+				clearTimeout(timer.current);
+			}
+		};
+	}, []);
 
 	return throttledCallback as T;
 }

--- a/src/hooks/common/useThrottle.ts
+++ b/src/hooks/common/useThrottle.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef } from "react";
+
+function useThrottle<T extends (...args: any[]) => void>(
+	callback: T,
+	delay: number,
+): T {
+	const isThrottling = useRef(false);
+
+	const throttledCallback = useCallback(
+		(...args: any[]) => {
+			if (!isThrottling.current) {
+				callback(...args);
+				isThrottling.current = true;
+				setTimeout(() => {
+					isThrottling.current = false;
+				}, delay);
+			}
+		},
+		[callback, delay],
+	);
+
+	return throttledCallback as T;
+}
+
+export default useThrottle;

--- a/src/hooks/common/useWindowWidth.ts
+++ b/src/hooks/common/useWindowWidth.ts
@@ -13,7 +13,7 @@ function useWindowWidth() {
 		}
 	};
 
-	const throttledHandleResize = useThrottle(handleResize, 100);
+	const throttledHandleResize = useThrottle(handleResize, 200);
 
 	useEffect(() => {
 		if (isClientSide) {

--- a/src/hooks/common/useWindowWidth.ts
+++ b/src/hooks/common/useWindowWidth.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+import useThrottle from "./useThrottle";
+
+function useWindowWidth() {
+	const isClientSide = typeof window !== "undefined";
+
+	const [width, setWidth] = useState(isClientSide ? window.innerWidth : 0);
+
+	const handleResize = () => {
+		if (isClientSide) {
+			setWidth(window.innerWidth);
+		}
+	};
+
+	const throttledHandleResize = useThrottle(handleResize, 100);
+
+	useEffect(() => {
+		if (isClientSide) {
+			window.addEventListener("resize", throttledHandleResize);
+			return () => {
+				window.removeEventListener("resize", throttledHandleResize);
+			};
+		}
+	}, [isClientSide, throttledHandleResize]);
+
+	return width;
+}
+
+export default useWindowWidth;

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,0 +1,5 @@
+import ProfilePageLayout from "@/components/profile/ProfilePageLayout";
+
+export default function UserProfilePage() {
+	return <ProfilePageLayout />;
+}

--- a/src/pages/profile/my.tsx
+++ b/src/pages/profile/my.tsx
@@ -1,0 +1,5 @@
+import ProfilePageLayout from "@/components/profile/ProfilePageLayout";
+
+export default function ProfilePage() {
+	return <ProfilePageLayout />;
+}

--- a/src/pages/profile/my.tsx
+++ b/src/pages/profile/my.tsx
@@ -1,5 +1,5 @@
 import ProfilePageLayout from "@/components/profile/ProfilePageLayout";
 
-export default function ProfilePage() {
+export default function MyProfilePage() {
 	return <ProfilePageLayout />;
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,6 +1,9 @@
-export type Category = {
-	updatedAt: string;
-	createdAt: string;
-	name: string;
+export type Base = {
 	id: number;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type Category = Base & {
+	name: string;
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,13 @@
+import { Base } from "./common";
+
+export type User = Base & {
+	teamId: string;
+	nickname: string;
+	image: string;
+};
+
+export type UserDetail = User & {
+	followeesCount: number;
+	followersCount: number;
+	isFollowing: boolean;
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,4 +10,5 @@ export type UserDetail = User & {
 	followeesCount: number;
 	followersCount: number;
 	isFollowing: boolean;
+	description: string;
 };


### PR DESCRIPTION
close #60 

### 📌 작업 사항

---

- [구현] 프로필 페이지 UI
  1. ProfilePageLayout
  2. ProfileCard
  3. ActivityDetails
  4. FilteredProductList (에서 참조할 BREAK_POINT 상수 포함)
- [구현] useWindowWidth 훅
- [구현] useThrottle 훅
- [수정] 드롭다운 외부에서 스타일 가능하게, 웹 표준 미준수 부분
- [수정] Image 컴포넌트 사용 시 모든 외부 경로도 허용하도록 임시로 next.config.mjs 수정
- [수정] ActivityCard, ProductCard 스타일 변경

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---

- 바뀐 파일이 많아 죄송합니다... 😢 새롭게 추가된 파일들만 보셔도 됩니다.
- route는 내 프로필의 경우 /profile/my, 다른 유저의 프로필은 /profile/[id] 로 만들었습니다.
- 원래는 라이브러리를 설치해 반응적으로 UI를 변경하려 했으나 직접 작성할 수 있다고 판단해 커스텀 훅 2개(useWindowWidth, useThrottle)를 만들었습니다.
- 일단 UI 확인을 위해 더미 데이터도 코드에 포함되어 있습니다. 기능 개발하며 삭제하겠습니다.
- ActivityCard, ProductCard 컴포넌트는 제가 작성한 게 아니지만 프로필 페이지에서만 사용되는 것 같아 스타일을 좀 건드렸습니다. 


### 📌 사용 방법 (선택)

---

- 페이지 UI는 route에 맞는 url을 입력하시면 확인하실 수 있습니다.

- `useWindowWidth` 훅의 경우 다음과 같이 사용하시면 현재 window의 innerWidth 값을 반환합니다.
  ```js
  const currentWidth = useWindowWidth();
  ```


- `useThrottle` 훅은 매개변수로 실행하고자 하는 콜백 함수와 ms 단위의 delay 값을 넘기면 스로틀링이 적용된 콜백 함수를 리턴합니다.
  ```js
  const throttledHandleResize = useThrottle(handleResize, 100);
  ```

### 📌 스크린샷 / 테스트결과 (선택)

---
