### PR TITLE
Feat: 비교 결과 UI

### DIFF
--- a/src/apis/products.ts
+++ b/src/apis/products.ts
@@ -1,4 +1,4 @@
-import { Product, ProductsResponse } from "@/types/product";
+import { ProductDetail, ProductsResponse } from "@/types/product";
 
 import instance from "./axiosInstance";
 
@@ -18,7 +18,7 @@ export async function getProducts(
 }
 
 export async function getProductDetail(productId: number) {
-	const res = await instance.get<Product>(`products/${productId}`);
+	const res = await instance.get<ProductDetail>(`products/${productId}`);
 	const data = res.data;
 
 	return data;

--- a/src/components/compare/CompareForm.tsx
+++ b/src/components/compare/CompareForm.tsx
@@ -24,7 +24,7 @@ export default function CompareForm() {
 
 	return (
 		<form
-			className="flex w-full flex-col gap-[1.2rem] md:w-full md:flex-row md:items-center md:justify-center md:gap-[2rem]"
+			className="flex w-full flex-col gap-[1.2rem] md:grid md:grid-cols-[repeat(2,minmax(0,1fr))_164px] md:items-center md:gap-[2rem] lg:grid-cols-[repeat(2,minmax(0,1fr))_200px]"
 			onSubmit={handleFormSubmit}
 		>
 			<CompareInput
@@ -41,7 +41,6 @@ export default function CompareForm() {
 				tagColor="pink"
 				setIsError={setIsError}
 			/>
-			{/* TODO: 버튼 내부 text가 w-full일 때, 가운데 정렬이 안되고 있음 */}
 			<BasicButton
 				label="비교하기"
 				className="_flex-center h-[5.5rem] w-full md:mt-2 md:w-[16.4rem] lg:h-[7rem] lg:w-[20rem]"

--- a/src/components/compare/CompareInput.tsx
+++ b/src/components/compare/CompareInput.tsx
@@ -34,7 +34,7 @@ export default function CompareInput(props: CompareInputProps) {
 				{label}
 			</label>
 			{/* todo: md 사이즈에서 input width가 늘어나지 않고 고정되어 있는 문제 */}
-			<div className="relative flex h-[5.5rem] w-full items-center justify-center rounded-[0.8rem] bg-black-border p-px focus-within:bg-main-gradient lg:h-[7rem] lg:w-[35rem]">
+			<div className="relative flex h-[5.5rem] w-full items-center justify-center rounded-[0.8rem] bg-black-border p-px focus-within:bg-main-gradient lg:h-[7rem]">
 				<div className="flex size-full items-center rounded-[0.8rem] bg-black-bg px-[2rem] py-[2.3rem] text-[1.4rem] text-white lg:text-[1.6rem] lg:leading-[2.2.rem]">
 					{product?.name ? (
 						<ProductNameTag

--- a/src/components/compare/EachResult.tsx
+++ b/src/components/compare/EachResult.tsx
@@ -1,0 +1,41 @@
+import clsx from "clsx";
+
+import { ResultOfComparison } from "@/types/compare";
+import { ProductDetail } from "@/types/product";
+
+type Props = {
+	property: "rating" | "reviewCount" | "favoriteCount";
+	product: ProductDetail;
+	winningProductIdForEachProperty: ResultOfComparison;
+	color: "green" | "pink";
+};
+
+export default function EachResult({
+	property,
+	product,
+	winningProductIdForEachProperty,
+	color,
+}: Props) {
+	const displayData = product[property];
+
+	const isWinner = winningProductIdForEachProperty[property] === product.id;
+
+	const winBadgeClassName = isWinner
+		? `text-${color} bg-${color} opacity-75`
+		: `text-transparent`;
+
+	return (
+		<div className="_flex-col-center gap-1 text-[1.6rem] text-white lg:text-[2rem]">
+			<span
+				className={clsx(
+					winBadgeClassName,
+					"rounded-2xl px-2 py-[0.1rem] text-[1.2rem] lg:text-[1.4rem]",
+				)}
+			>
+				승리
+			</span>
+
+			{displayData}
+		</div>
+	);
+}

--- a/src/components/compare/EachResultImage.tsx
+++ b/src/components/compare/EachResultImage.tsx
@@ -1,0 +1,16 @@
+import Image from "next/image";
+
+import { ProductDetail } from "@/types/product";
+
+type Props = {
+	product: ProductDetail;
+};
+
+export default function EachResultImage({ product }: Props) {
+	const { image: imageSrc, name } = product;
+	return (
+		<div className="relative size-48 overflow-hidden rounded-full sm:size-64 md:size-80 lg:size-96">
+			<Image src={imageSrc} alt={name} fill className="absolute left-0 top-0" />
+		</div>
+	);
+}

--- a/src/components/compare/EachResultLayout.tsx
+++ b/src/components/compare/EachResultLayout.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+
+import EachResult from "./EachResult";
+import EachResultImage from "./EachResultImage";
+import EachResultLink from "./EachResultLink";
+import EachResultTitle from "./EachResultTitle";
+
+type Props = {
+	title?: string;
+	children: ReactNode;
+};
+
+export default function EachResultLayout({ title, children }: Props) {
+	return (
+		<div>
+			{title && (
+				<p className="text-[1.6rem] text-gray-100 after:mb-2 after:mt-4 after:block after:h-[0.1rem] after:bg-black-border lg:text-[2rem] after:lg:mt-6">
+					{title}
+				</p>
+			)}
+			<div className="grid grid-cols-2 justify-items-center gap-8 md:gap-12 lg:gap-16">
+				{children}
+			</div>
+		</div>
+	);
+}
+
+EachResultLayout.Image = EachResultImage;
+EachResultLayout.Link = EachResultLink;
+EachResultLayout.Title = EachResultTitle;
+EachResultLayout.Result = EachResult;

--- a/src/components/compare/EachResultLink.tsx
+++ b/src/components/compare/EachResultLink.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ProductDetail } from "@/types/product";
+
+type Props = {
+	product: ProductDetail;
+};
+
+export default function EachResultLink({ product }: Props) {
+	const { id } = product;
+
+	return (
+		<Link
+			href={`productdetail/${id}`}
+			className="_flex-center gap-1 p-3 text-[1.4rem] text-gray-100 hover:text-white"
+		>
+			<Image
+				src="/icons/search.svg"
+				alt="상품 상세 페이지로 이동"
+				width={14}
+				height={14}
+			/>
+			더 알아보기
+		</Link>
+	);
+}

--- a/src/components/compare/EachResultTitle.tsx
+++ b/src/components/compare/EachResultTitle.tsx
@@ -1,0 +1,20 @@
+import { ProductDetail } from "@/types/product";
+
+type Props = {
+	product: ProductDetail;
+};
+
+export default function EachResultTitle({ product }: Props) {
+	const { name, description } = product;
+
+	return (
+		<div className="_flex-col-center gap-3">
+			<p className="text-center text-[1.8rem] text-white lg:text-[2.4rem]">
+				{name}
+			</p>
+			<p className="_text-overflow text-[1.2rem] text-gray-100 lg:text-[1.4rem]">
+				{description}
+			</p>
+		</div>
+	);
+}

--- a/src/components/compare/FinalResultDescription.tsx
+++ b/src/components/compare/FinalResultDescription.tsx
@@ -1,0 +1,36 @@
+import { cva, VariantProps } from "class-variance-authority";
+
+import { WinningProduct } from "@/types/compare";
+
+type Props = {
+	winningProduct: WinningProduct;
+};
+
+export default function FinalResultDescription({ winningProduct }: Props) {
+	const { name, numberOfWins, tagColor } = winningProduct;
+
+	const isTie = name === "무승부";
+
+	const tagColorClassName = `text-${tagColor}`;
+
+	return (
+		<div className="_flex-col-center gap-[2rem]">
+			<p className="text-center text-[2rem] font-semibold leading-[2.8rem] text-white lg:text-[2.4rem] lg:leading-normal">
+				<span className={tagColorClassName}>{`${name} `}</span>
+				{isTie ? (
+					<span>입니다.</span>
+				) : (
+					<span>
+						상품이 <br className="lg:hidden" />
+						승리하였습니다!
+					</span>
+				)}
+			</p>
+			{!isTie && (
+				<p className="text-[1.2rem] text-gray-100 lg:text-[1.6rem]">
+					3가지 항목 중 <span>{numberOfWins}</span>가지 항목에서 우세합니다.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/components/compare/Result.tsx
+++ b/src/components/compare/Result.tsx
@@ -1,0 +1,88 @@
+import { ProductDetail } from "@/types/product";
+import {
+	getWinningProduct,
+	getWinningProductIdForEachProperty,
+} from "@/utils/compare";
+
+import EachResultLayout from "./EachResultLayout";
+import FinalResultDescription from "./FinalResultDescription";
+
+type Props = {
+	firstProduct: ProductDetail;
+	secondProduct: ProductDetail;
+};
+
+export default function Result({ firstProduct, secondProduct }: Props) {
+	const winningProductIdForEachProperty = getWinningProductIdForEachProperty(
+		firstProduct,
+		secondProduct,
+	);
+
+	const winningProduct = getWinningProduct(firstProduct, secondProduct);
+
+	return (
+		<div className="_flex-col-center gap-16">
+			<FinalResultDescription winningProduct={winningProduct} />
+			<div>
+				<EachResultLayout>
+					<EachResultLayout.Image product={firstProduct} />
+					<EachResultLayout.Image product={secondProduct} />
+				</EachResultLayout>
+				<div className="my-2 lg:my-4">
+					<EachResultLayout>
+						<EachResultLayout.Link product={firstProduct} />
+						<EachResultLayout.Link product={secondProduct} />
+					</EachResultLayout>
+				</div>
+				<div className="my-4 lg:my-8">
+					<EachResultLayout title="제품 설명">
+						<EachResultLayout.Title product={firstProduct} />
+						<EachResultLayout.Title product={secondProduct} />
+					</EachResultLayout>
+				</div>
+				<EachResultLayout title="별점">
+					<EachResultLayout.Result
+						property="rating"
+						product={firstProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="green"
+					/>
+					<EachResultLayout.Result
+						property="rating"
+						product={secondProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="pink"
+					/>
+				</EachResultLayout>
+				<EachResultLayout title="찜 개수">
+					<EachResultLayout.Result
+						property="favoriteCount"
+						product={firstProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="green"
+					/>
+					<EachResultLayout.Result
+						property="favoriteCount"
+						product={secondProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="pink"
+					/>
+				</EachResultLayout>
+				<EachResultLayout title="리뷰 개수">
+					<EachResultLayout.Result
+						property="reviewCount"
+						product={firstProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="green"
+					/>
+					<EachResultLayout.Result
+						property="reviewCount"
+						product={secondProduct}
+						winningProductIdForEachProperty={winningProductIdForEachProperty}
+						color="pink"
+					/>
+				</EachResultLayout>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -1,18 +1,74 @@
 import CompareForm from "@/components/compare/CompareForm";
+import Result from "@/components/compare/Result";
 import useCompareQueries from "@/hooks/compare/useCompareQueries";
+import { ProductDetail } from "@/types/product";
+
+const firstProduct: ProductDetail = {
+	id: 1,
+	name: "iphone pro 15",
+	description:
+		"Super Retina XDR 디스플레이1, ProMotion 기술, 상시표시형 디스플레이",
+	image: "/images/testImage.png",
+	rating: 4.5,
+	reviewCount: 100,
+	favoriteCount: 50,
+	categoryId: 6,
+	updatedAt: "2024-03-13 06:30:20",
+	createdAt: "2024-03-13 06:30:20",
+	writerId: 1,
+	isFavorite: false,
+	category: {
+		id: 6,
+		name: "전자기기",
+	},
+	categoryMetric: {
+		rating: 4.0,
+		favoriteCount: 45,
+		reviewCount: 110,
+	},
+};
+
+const secondProduct: ProductDetail = {
+	id: 2,
+	name: "iphone pro 15 Max",
+	description:
+		"Super Retina XDR 디스플레이1, ProMotion 기술, 상시표시형 디스플레이",
+	image: "/images/testImage.png",
+	rating: 4.7,
+	reviewCount: 80,
+	favoriteCount: 40,
+	categoryId: 6,
+	updatedAt: "2024-03-13 06:30:20",
+	createdAt: "2024-03-13 06:30:20",
+	writerId: 1,
+	isFavorite: false,
+	category: {
+		id: 6,
+		name: "전자기기",
+	},
+	categoryMetric: {
+		rating: 4.0,
+		favoriteCount: 45,
+		reviewCount: 110,
+	},
+};
 
 export default function Index() {
-	const {
-		products: { firstProduct, secondProduct },
-	} = useCompareQueries();
+	// const {
+	// 	products: { firstProduct, secondProduct },
+	// } = useCompareQueries();
 
 	return (
-		<div className="h-screen bg-[#1c1c22]">
-			<CompareForm />
-			<div>
-				{/* todo: 결과 테이블 UI 구현 */}
-				<p>{firstProduct?.name}</p>
-				<p>{secondProduct?.name}</p>
+		<div className="h-full min-h-screen bg-[#1c1c22]">
+			<div className="_flex-col-center mx-8 gap-24 pb-16 pt-12 md:mx-12 md:max-w-[94rem] md:pb-40 md:pt-16 lg:mx-auto lg:w-[94rem] lg:gap-32 lg:pt-24">
+				<CompareForm />
+				<div>
+					{firstProduct && secondProduct ? (
+						<Result firstProduct={firstProduct} secondProduct={secondProduct} />
+					) : (
+						<div>로딩 중</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,7 +33,7 @@ html {
 	._flex-col-center {
 		@apply flex flex-col items-center justify-center;
 	}
-  
+
 	._pos-center {
 		@apply top-2/4 left-2/4 -translate-x-2/4 -translate-y-2/4;
 	}
@@ -41,6 +41,16 @@ html {
 
 button {
 	cursor: pointer;
+}
+
+._text-overflow {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	word-break: break-word;
+
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
 }
 
 @font-face {

--- a/src/types/compare.ts
+++ b/src/types/compare.ts
@@ -1,0 +1,13 @@
+export type CompareProperty = "rating" | "reviewCount" | "favoriteCount";
+
+export type ResultOfComparison = {
+	rating: number;
+	reviewCount: number;
+	favoriteCount: number;
+};
+
+export type WinningProduct = {
+	name: string;
+	numberOfWins: number;
+	tagColor: "white" | "green" | "pink";
+};

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,0 +1,105 @@
+import {
+	CompareProperty,
+	ResultOfComparison,
+	WinningProduct,
+} from "@/types/compare";
+import { ProductDetail } from "@/types/product";
+
+/**
+ * 파라미터로 전달받은 제품 2개를 정해진 속성들에 대해서 어떤 제품이 더 큰 값을 가지고 있는지 비교하는 함수
+ * @param firstProduct 비교 상품 1
+ * @param secondProduct 비교 상품 2
+ * @returns 정해진 속성들을 key로 하고, 정해진 속성마다 더 큰 값을 가지고 있는 상품의 id를 value로 하는 객체를 반환
+ */
+export function getWinningProductIdForEachProperty(
+	firstProduct: ProductDetail,
+	secondProduct: ProductDetail,
+) {
+	const winningProductIdForEachProperty: ResultOfComparison = {
+		rating: 0,
+		reviewCount: 0,
+		favoriteCount: 0,
+	};
+
+	const propertiesToCompare: CompareProperty[] = [
+		"rating",
+		"reviewCount",
+		"favoriteCount",
+	];
+
+	propertiesToCompare.forEach((property) => {
+		const id = winningIdForEachProperty(firstProduct, secondProduct, property);
+
+		id && (winningProductIdForEachProperty[property] = id);
+	});
+
+	return winningProductIdForEachProperty;
+}
+
+function winningIdForEachProperty(
+	firstProduct: ProductDetail,
+	secondProduct: ProductDetail,
+	property: "rating" | "reviewCount" | "favoriteCount",
+) {
+	if (firstProduct[property] === secondProduct[property]) {
+		return;
+	}
+
+	if (firstProduct[property] > secondProduct[property]) {
+		return firstProduct.id;
+	} else {
+		return secondProduct.id;
+	}
+}
+
+/**
+ * 최종적으로 이긴 제품이 무엇인지 구하는 함수
+ * @param firstProduct 비교 상품 1
+ * @param secondProduct 비교 상품 2
+ * @returns 인자로 받은 제품 중, 최종적으로 이긴 제품의 이름과 몇 개의 분야에서 이겼는지, 이긴 상품이름을 어떤 색상으로 표시할 것인지를 객체로 리턴
+ */
+export function getWinningProduct(
+	firstProduct: ProductDetail,
+	secondProduct: ProductDetail,
+) {
+	const resultOfComparison = getWinningProductIdForEachProperty(
+		firstProduct,
+		secondProduct,
+	);
+
+	const numberOfWinningForEachProduct = {
+		[firstProduct.id]: 0,
+		[secondProduct.id]: 0,
+	};
+
+	for (let [property, winningId] of Object.entries(resultOfComparison)) {
+		winningId && numberOfWinningForEachProduct[winningId]++;
+	}
+
+	const winningProduct: WinningProduct = {
+		name: "무승부",
+		numberOfWins: 0,
+		tagColor: "white",
+	};
+
+	const winningCountOfFirstProduct =
+		numberOfWinningForEachProduct[firstProduct.id];
+	const winningCountOfSecondProduct =
+		numberOfWinningForEachProduct[secondProduct.id];
+
+	if (winningCountOfFirstProduct === winningCountOfSecondProduct) {
+		return winningProduct;
+	}
+
+	if (winningCountOfFirstProduct > winningCountOfSecondProduct) {
+		winningProduct.name = firstProduct.name;
+		winningProduct.numberOfWins = winningCountOfFirstProduct;
+		winningProduct.tagColor = "green";
+	} else {
+		winningProduct.name = secondProduct.name;
+		winningProduct.numberOfWins = winningCountOfSecondProduct;
+		winningProduct.tagColor = "pink";
+	}
+
+	return winningProduct;
+}


### PR DESCRIPTION
Close #87 

### 📌 작업 사항

---

- [변경] 비교하기 상품 입력 인풋 창 : 태블릿일 때부터는 grid로 display 변경
- [구현] utils/compare.ts : 두 상품의 비교 결과를 반환하는 함수들 구현
- [구현] 비교 결과를 나타내는 UI 컴포넌트들 구현
- [추가] global.css : 텍스트를 2줄까지만 표시하고 나머지 부분은 ...으로 표시하도록 하는 css 변수를 추가했습니다.

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 보시다가 더 괜찮은 네이밍 아이디어 있으시면 알려주세요. 적절한 컴포넌트 이름을 생각해내지 못해서 대충 적었어요.ㅋㅋ
- 제 임의대로 디자인 했는데, 의견주세요 ㅎㅎ
- 생각나는대로 작성한 함수, 컴포넌트라 뭔가 반복되는 코드가 많은 것 같은데, 딱히 줄일 아이디어가 떠오르지 않네요.

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
<img width="610" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/141597336/17fb559c-e650-40c6-9f7b-4138c8d79cb6">
