### PR TITLE
feat: 유저가/를 팔로우 하는 유저 목록 모달

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,25 @@
+import { FolloweesResponse, FollowersResponse } from "@/types/user";
+
+import instance from "./axiosInstance";
+
+export const getUserFollowees = async (
+	userId: number,
+	cursor?: number,
+): Promise<FolloweesResponse> => {
+	const cursorParam = cursor ? `?cursor=${cursor}` : "";
+	const response = await instance.get<FolloweesResponse>(
+		`users/${userId}/followees${cursorParam}`,
+	);
+	return response.data;
+};
+
+export const getUserFollowers = async (
+	userId: number,
+	cursor?: number,
+): Promise<FollowersResponse> => {
+	const cursorParam = cursor ? `?cursor=${cursor}` : "";
+	const response = await instance.get<FollowersResponse>(
+		`users/${userId}/followers${cursorParam}`,
+	);
+	return response.data;
+};

--- a/src/components/profile/FollowUsersModal.tsx
+++ b/src/components/profile/FollowUsersModal.tsx
@@ -1,14 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { getUserFollowees, getUserFollowers } from "@/apis/user";
+import ProfileImage from "@/components/common/profileImage/ProfileImage";
 import {
 	Followee,
 	Follower,
 	UserDetail,
 	UserResponseByVariant,
 } from "@/types/user";
-
-import ProfileImage from "../common/profileImage/ProfileImage";
 
 type Props = {
 	variant: "followee" | "follower";

--- a/src/components/profile/FollowUsersModal.tsx
+++ b/src/components/profile/FollowUsersModal.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getUserFollowees, getUserFollowers } from "@/apis/user";
+import {
+	Followee,
+	Follower,
+	UserDetail,
+	UserResponseByVariant,
+} from "@/types/user";
+
+import ProfileImage from "../common/profileImage/ProfileImage";
+
+type Props = {
+	variant: "followee" | "follower";
+	owner: UserDetail;
+};
+
+export default function FollowUsersModal({
+	variant = "followee",
+	owner,
+}: Props) {
+	const { data: usersResponse } = useQuery<
+		UserResponseByVariant[typeof variant]
+	>({
+		queryKey: [variant, owner.id],
+		queryFn: () =>
+			variant === "followee"
+				? getUserFollowees(owner.id)
+				: getUserFollowers(owner.id),
+	});
+	const users = usersResponse?.list;
+
+	const renderUser = (item: Followee | Follower) => {
+		const user =
+			variant === "followee"
+				? (item as Followee).followee
+				: (item as Follower).follower;
+		return (
+			<li key={user.id}>
+				<button className="flex items-center gap-[2rem]">
+					<ProfileImage src={user.image} size="medium" />
+					<span className="text-[1.6rem] font-medium text-white lg:text-[1.8rem]">
+						{user.nickname}
+					</span>
+				</button>
+			</li>
+		);
+	};
+
+	return (
+		<div className="flex flex-col gap-[2rem] px-[2rem]">
+			<h3 className="text-[2rem] font-semibold text-white lg:text-[2.4rem]">
+				{owner.nickname}님{variant === "followee" ? "을" : "이"} 팔로우하는 유저
+			</h3>
+			{users?.length ? (
+				<ul className="flex flex-col gap-[2rem]">
+					{users?.map((item) => renderUser(item))}
+				</ul>
+			) : (
+				<div className="text-center text-[1.8rem] text-gray-400 lg:text-[2rem]">
+					팔로우하는 유저가 없습니다.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -3,6 +3,7 @@ import ProfileImage from "@/components/common/profileImage/ProfileImage";
 import { useModalActions } from "@/store/modal";
 import { UserDetail } from "@/types/user";
 
+import FollowUsersModal from "./FollowUsersModal";
 import ProfileModifyModal from "./ProfileModifyModal";
 
 type Props = {
@@ -20,6 +21,14 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 		);
 	};
 
+	const handleOpenFolloweesModal = () => {
+		openModal(<FollowUsersModal variant="followee" owner={user} />);
+	};
+
+	const handleOpenFollowersModal = () => {
+		openModal(<FollowUsersModal variant="follower" owner={user} />);
+	};
+
 	return (
 		<section className="_flex-col-center w-[33.5rem] gap-[3rem] rounded-[1.2rem] border border-black-border bg-black-bg px-[2rem] py-[3rem] md:w-[50.9rem] lg:w-[34rem]">
 			<h2 className="sr-only">기본 정보</h2>
@@ -34,14 +43,14 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 				<p className="text-[1.4rem] text-gray-200">{user.description}</p>
 			</div>
 			<div className="flex w-full justify-evenly">
-				<button className="_flex-col-center">
+				<button className="_flex-col-center" onClick={handleOpenFolloweesModal}>
 					<span className="text-[1.8rem] font-semibold text-white">
 						{user.followeesCount}
 					</span>
 					<span className="text-[1.4rem] text-gray-100">팔로워</span>
 				</button>
 				<div className="h-[4.8rem] w-[1px] bg-black-border"></div>
-				<button className="_flex-col-center">
+				<button className="_flex-col-center" onClick={handleOpenFollowersModal}>
 					<span className="text-[1.8rem] font-semibold text-white">
 						{user.followersCount}
 					</span>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,17 +16,17 @@ function Providers({ children }: { children: ReactNode }) {
 
 	return (
 		<>
-			{modals.map((modal) => (
-				<ModalWrapper
-					id={modal.id}
-					key={modal.id}
-					onRemove={() => closeModal(modal.id)}
-					config={modal.config}
-				>
-					{modal.content}
-				</ModalWrapper>
-			))}
 			<QueryClientProvider client={queryClient}>
+				{modals.map((modal) => (
+					<ModalWrapper
+						id={modal.id}
+						key={modal.id}
+						onRemove={() => closeModal(modal.id)}
+						config={modal.config}
+					>
+						{modal.content}
+					</ModalWrapper>
+				))}
 				{children}
 				<ReactQueryDevtools initialIsOpen={false} />
 			</QueryClientProvider>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
-import { Base } from "./common";
+import { Base, Response } from "./common";
 
 export type User = Base & {
 	teamId: string;
@@ -11,4 +11,22 @@ export type UserDetail = User & {
 	followersCount: number;
 	isFollowing: boolean;
 	description: string;
+};
+
+export type Followee = {
+	followee: User;
+	id: number;
+};
+
+export type Follower = {
+	follower: User;
+	id: number;
+};
+
+export type FolloweesResponse = Response<Followee>;
+export type FollowersResponse = Response<Follower>;
+
+export type UserResponseByVariant = {
+	followee: FolloweesResponse;
+	follower: FollowersResponse;
 };


### PR DESCRIPTION
close #116 

### 📌 작업 사항

---

- [구현] 유저가, 혹은 유저를 팔로우 하는 유저 목록 모달 UI, 기능
- [변경] _app.tsx 의 모달 위치 변경

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- _app.tsx 에서 모달이 렌더링 되는 위치를 QueryClientProvider 내부로 바꿨습니다. 그렇지 않으면 react-query를 사용할 수 없더라구요..

### 📌 사용 방법 (선택)

---

아직 더미 유저를 계속 사용하고 있기 때문에 테스트 시 더미 유저의 id 를 변경해서 확인하실 수 있습니다.

### 📌 스크린샷 / 테스트결과 (선택)

---
<img width="532" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/9549ec0e-271d-422e-99b0-f6280186dbf8">
<img width="450" alt="image" src="https://github.com/4-2-mogazoa/mogazoa/assets/44164404/3aede3ba-253a-4435-bc3a-0bd000e434ee">
