### PR TITLE
feat: 유저 모달 기능

### DIFF
--- a/src/components/user/FollowUsersModal.tsx
+++ b/src/components/user/FollowUsersModal.tsx
@@ -1,7 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { Fragment } from "react";
 
 import { getUserFollowees, getUserFollowers } from "@/apis/user";
 import ProfileImage from "@/components/common/profileImage/ProfileImage";
+import { useIntersect } from "@/hooks/common/useIntersect";
+import { useModalActions } from "@/store/modal";
 import {
 	Followee,
 	Follower,
@@ -18,42 +22,61 @@ export default function FollowUsersModal({
 	variant = "followee",
 	owner,
 }: Props) {
-	const { data: usersResponse } = useQuery<
+	const { closeAllModals } = useModalActions();
+	const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery<
 		UserResponseByVariant[typeof variant]
 	>({
 		queryKey: [variant, owner.id],
-		queryFn: () =>
+		queryFn: ({ pageParam }) =>
 			variant === "followee"
-				? getUserFollowees(owner.id)
-				: getUserFollowers(owner.id),
+				? getUserFollowees(owner.id, pageParam as number)
+				: getUserFollowers(owner.id, pageParam as number),
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.nextCursor,
 	});
-	const users = usersResponse?.list;
 
-	const renderUser = (item: Followee | Follower) => {
-		const user =
-			variant === "followee"
-				? (item as Followee).followee
-				: (item as Follower).follower;
-		return (
-			<li key={user.id}>
-				<button className="flex items-center gap-[2rem]">
-					<ProfileImage src={user.image} size="medium" />
-					<span className="text-[1.6rem] font-medium text-white lg:text-[1.8rem]">
-						{user.nickname}
-					</span>
-				</button>
-			</li>
-		);
-	};
+	const intersectRef = useIntersect<HTMLLIElement>(
+		async (entry, observer) => {
+			observer.unobserve(entry.target);
+			if (hasNextPage && !isFetching) {
+				fetchNextPage();
+			}
+		},
+		{ rootMargin: "50px" },
+	);
 
 	return (
-		<div className="flex flex-col gap-[2rem] px-[2rem]">
+		<div className="flex max-h-[50rem] flex-col gap-[2rem] px-[2rem] md:max-h-[55rem] lg:max-h-[60rem]">
 			<h3 className="text-[2rem] font-semibold text-white lg:text-[2.4rem]">
 				{owner.nickname}님{variant === "followee" ? "을" : "이"} 팔로우하는 유저
 			</h3>
-			{users?.length ? (
-				<ul className="flex flex-col gap-[2rem]">
-					{users?.map((item) => renderUser(item))}
+			{data?.pages[0].list.length ? (
+				<ul className="flex flex-col gap-[2rem] overflow-auto">
+					{data.pages.map((users, i) => (
+						<Fragment key={i}>
+							{users.list.map((item, idx, arr) => {
+								const isLastItem = idx === arr.length - 1;
+								const user =
+									variant === "followee"
+										? (item as Followee).followee
+										: (item as Follower).follower;
+								return (
+									<li key={user.id} ref={isLastItem ? intersectRef : null}>
+										<Link
+											href={`/user/${user.id}`}
+											className="flex items-center gap-[2rem]"
+											onClick={closeAllModals}
+										>
+											<ProfileImage src={user.image} size="medium" />
+											<span className="text-[1.6rem] font-medium text-white lg:text-[1.8rem]">
+												{user.nickname}
+											</span>
+										</Link>
+									</li>
+								);
+							})}
+						</Fragment>
+					))}
 				</ul>
 			) : (
 				<div className="text-center text-[1.8rem] text-gray-400 lg:text-[2rem]">

--- a/src/hooks/common/useIntersect.ts
+++ b/src/hooks/common/useIntersect.ts
@@ -5,11 +5,11 @@ type IntersectHandler = (
 	observer: IntersectionObserver,
 ) => void;
 
-export const useIntersect = (
+export const useIntersect = <T extends HTMLElement = HTMLDivElement>(
 	onIntersect: IntersectHandler,
 	options?: IntersectionObserverInit,
 ) => {
-	const ref = useRef<HTMLDivElement>(null);
+	const ref = useRef<T>(null);
 	const callback = useCallback(
 		(entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
 			entries.forEach((entry) => {


### PR DESCRIPTION
close #147 

유저 클릭 시 모달 닫히며 해당 유저 페이지 이동
무한 스크롤(useIntersect 제네릭으로 변경)

### 📌 작업 사항

---

- [구현] 유저 클릭 시 모달 닫히며 해당 유저 페이지 이동
- [구현] 팔로우 유저 목록 무한 스크롤
- [수정] useIntersect 파일의 ref 타입 제네릭 받을 수 있도록 변경


### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---

무한 스크롤이 어떤 위치에서 다음 내용을 fetch 해 와야 적절한지 고민입니다.
모달의 스크롤 크기가 너무 커 나중에 스타일링을 좀 해야할 것 같습니다.

