### PR TITLE
feat: 상품상세화면 비교하기모달 연결

### DIFF
--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -1,4 +1,4 @@
-import { Images, Me, Review, ReviewDelete } from "@/types/review";
+import { Images, Review, ReviewDelete } from "@/types/review";
 
 import instance from "./axiosInstance";
 
@@ -41,12 +41,6 @@ export async function modifyReview(
 		content,
 		rating,
 	});
-
-	return res.data;
-}
-
-export async function getUserMe() {
-	const res = await instance.get<Me>("users/me");
 
 	return res.data;
 }

--- a/src/components/productdetail/DetailCard.tsx
+++ b/src/components/productdetail/DetailCard.tsx
@@ -3,9 +3,11 @@ import clsx from "clsx";
 import Image from "next/image";
 
 import { deleteFavorite, postFavorite } from "@/apis/products";
+import useCompareModal from "@/hooks/compare/useCompareModal";
 import { useModalActions } from "@/store/modal";
 import { ProductDetail } from "@/types/product";
 import cn from "@/utils/cn";
+import getCookies from "@/utils/getCookies";
 
 import BasicButton from "../common/button/BasicButton";
 import CategoryBadge from "../common/categoryBadge/CategoryBadge";
@@ -45,6 +47,14 @@ export default function DetailCard({ productData, isMyProduct }: Props) {
 			},
 		);
 	};
+
+	const cookie = getCookies();
+	const accessToken = cookie["accessToken"];
+
+	const { compareButtonText, handleCompareButtonClick } = useCompareModal(
+		productData,
+		accessToken,
+	);
 
 	return (
 		<div className="flex min-w-[33.5rem] flex-col items-center md:flex-row lg:justify-between">
@@ -89,13 +99,13 @@ export default function DetailCard({ productData, isMyProduct }: Props) {
 						onClick={handleReviewCreateButton}
 					/>
 					<BasicButton
-						label="비교하기"
+						label={compareButtonText}
 						variant="secondary"
 						className={clsx("md:max-w-[12.3rem] lg:max-w-[18rem]", {
 							"md:max-w-[10.7rem] lg:max-w-[16rem]": isMyProduct,
 						})}
+						onClick={handleCompareButtonClick}
 					/>
-					{/**TODO: 비교상품 없을 경우 alert표시, 하나 있을 경우 확인할지 안할지 모달 표시 확인하면 /compare 이동, 두개 있을 경우 비교 상품 교체 모달 비로그인시 로그인 요청 모달*/}
 					{isMyProduct && (
 						<BasicButton
 							label="편집하기"
@@ -128,7 +138,7 @@ export function Share({ className }: ShareProps) {
 
 	return (
 		<div className={cn("flex gap-[1rem]", className)}>
-			<button className="flex size-[2.4rem] items-center justify-center rounded-[0.6rem] bg-black-bg lg:size-[2.8rem]">
+			<button className="bg-black-bg flex size-[2.4rem] items-center justify-center rounded-[0.6rem] lg:size-[2.8rem]">
 				<div className="relative size-[1.4rem] lg:size-[1.8rem]">
 					<Image
 						src="/icons/kakaotalk.svg"
@@ -140,7 +150,7 @@ export function Share({ className }: ShareProps) {
 			</button>
 			{/**TODO: 카카오공유는 배포이후 추가 가능*/}
 			<button
-				className="flex size-[2.4rem] items-center justify-center rounded-[0.6rem] bg-black-bg lg:size-[2.8rem]"
+				className="bg-black-bg flex size-[2.4rem] items-center justify-center rounded-[0.6rem] lg:size-[2.8rem]"
 				onClick={handleCopyClipBoard}
 			>
 				<div className="relative size-[1.4rem] lg:size-[1.8rem]">

--- a/src/components/productdetail/ProductDetail.tsx
+++ b/src/components/productdetail/ProductDetail.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { getProductDetail } from "@/apis/products";
-import { getUserMe } from "@/apis/review";
+import { getMe } from "@/apis/user";
 
 import DetailCard from "./DetailCard";
 import NoneReview from "./NoneReview";
@@ -17,8 +17,8 @@ export default function ProductDetail({ id }: { id: number }) {
 		enabled: !!id,
 	});
 	const myData = useQuery({
-		queryKey: ["usersMe"],
-		queryFn: () => getUserMe(),
+		queryKey: ["me"],
+		queryFn: () => getMe(),
 	}).data;
 
 	return (

--- a/src/components/productdetail/ProductReview.tsx
+++ b/src/components/productdetail/ProductReview.tsx
@@ -2,7 +2,7 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { getReviews } from "@/apis/products";
-import { getUserMe } from "@/apis/review";
+import { getMe } from "@/apis/user";
 import { filterBy } from "@/constants/filterBy";
 import { useIntersectionObserver } from "@/hooks/common/useIntersectionObserver";
 import useThrottle from "@/hooks/common/useThrottle";
@@ -45,8 +45,8 @@ export default function ProductReview({ id }: { id: number }) {
 	});
 
 	const myData = useQuery({
-		queryKey: ["usersMe"],
-		queryFn: () => getUserMe(),
+		queryKey: ["me"],
+		queryFn: () => getMe(),
 	}).data;
 
 	const handleOnSelect = (item: { id: number; name: string }) => {

--- a/src/components/productdetail/ReviewModal.tsx
+++ b/src/components/productdetail/ReviewModal.tsx
@@ -91,7 +91,12 @@ export default function ReviewModal({
 
 	useEffect(() => {
 		for (let i = 0; i <= 2; i++) {
-			getImage(i);
+			const existingImage = image.find(
+				(img) => img.id === editorData[i]?.id && img.image,
+			);
+			if (!existingImage) {
+				getImage(i);
+			}
 		}
 	}, [editorData.length, trigger]);
 

--- a/src/components/productdetail/ReviewModal.tsx
+++ b/src/components/productdetail/ReviewModal.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useRef, useState } from "react";
 
 import { getImageURL } from "@/apis/getImage";
 import { getProductDetail } from "@/apis/products";
@@ -39,6 +39,7 @@ export default function ReviewModal({
 	const [errMsg, setErrMsg] = useState("");
 	const [rateErrMsg, setRateErrMsg] = useState("");
 	const [trigger, setTrigger] = useState(0);
+	const [editImageId, setEditImageId] = useState<string | undefined>("");
 
 	const queryClient = useQueryClient();
 
@@ -89,12 +90,17 @@ export default function ReviewModal({
 		},
 	});
 
+	const prevTrigger = useRef(trigger);
 	useEffect(() => {
 		for (let i = 0; i <= 2; i++) {
 			const existingImage = image.find(
 				(img) => img.id === editorData[i]?.id && img.image,
 			);
-			if (!existingImage) {
+
+			if (
+				!existingImage ||
+				(prevTrigger.current !== trigger && editImageId === editorData[i]?.id)
+			) {
 				getImage(i);
 			}
 		}
@@ -118,13 +124,10 @@ export default function ReviewModal({
 
 	const handleOnClick = () => {
 		rating ? setRateErrMsg("") : setRateErrMsg("별점으로 상품을 평가해주세요.");
-
-		if (
-			rating &&
-			image.length >= 1 &&
-			content.length >= 10 &&
-			type === "create"
-		) {
+		if (content.length === 0) {
+			setErrMsg("리뷰 내용을 입력해주세요.");
+		}
+		if (rating && content.length >= 10 && type === "create") {
 			create();
 		}
 		if (
@@ -227,6 +230,7 @@ export default function ReviewModal({
 						setImage={setImage}
 						type={type}
 						setTrigger={setTrigger}
+						setEditImageId={setEditImageId}
 					/>
 				</div>
 			</div>

--- a/src/components/productdetail/ReviewModal.tsx
+++ b/src/components/productdetail/ReviewModal.tsx
@@ -130,12 +130,7 @@ export default function ReviewModal({
 		if (rating && content.length >= 10 && type === "create") {
 			create();
 		}
-		if (
-			rating &&
-			(image.length >= 1 || previousImage.length >= 1) &&
-			content.length >= 10 &&
-			type === "modify"
-		) {
+		if (rating && content.length >= 10 && type === "modify") {
 			modify();
 		}
 	};

--- a/src/components/productdetail/ReviewModalAddImageBox.tsx
+++ b/src/components/productdetail/ReviewModalAddImageBox.tsx
@@ -27,6 +27,7 @@ type Props = {
 	setPreviousImage: Dispatch<SetStateAction<ImageType[]>>;
 	setImage: Dispatch<SetStateAction<ImageType[]>>;
 	setTrigger: Dispatch<SetStateAction<number>>;
+	setEditImageId: Dispatch<SetStateAction<string | undefined>>;
 };
 
 export default function ReviewModalAddImageBox({
@@ -37,6 +38,7 @@ export default function ReviewModalAddImageBox({
 	setPreviousImage,
 	setImage,
 	setTrigger,
+	setEditImageId,
 }: Props) {
 	const fileRef = useRef<HTMLInputElement>(null);
 
@@ -162,6 +164,7 @@ export default function ReviewModalAddImageBox({
 							: imgData,
 					),
 				);
+				setEditImageId(id);
 				setTrigger((prev) => prev + 1);
 			};
 		}

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -43,23 +43,5 @@ export type ReviewDelete = {
 };
 
 export type img = { id: number } | { source: string };
-export type Images = img[];
 
-export type Me = {
-	id: number;
-	nickname: string;
-	description: string;
-	image: string;
-	createdAt: string;
-	updatedAt: string;
-	teamId: string;
-	isFollowing: boolean;
-	followersCount: number;
-	followeesCount: number;
-	reviewCount: number;
-	averageRating: number;
-	mostFavoriteCategory: {
-		id: number;
-		name: string;
-	};
-};
+export type Images = img[];


### PR DESCRIPTION
Close #152 
### 📌 작업 사항

---
[구현] 상품상세 페이지 비교하기 모달 연결

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---
- 비교하기 테스트 모달에서 getServerSideProps로 쿠키를 받아오는 부분은  클라이언트에서 getCookies 함수로 가져오도록 했어요.
- 멘토링때 말씀드린거처럼 내 정보 조회 api와 쿼리키는 찬주님이 작성하셨던걸로 수정했습니다.
- 동일한 이미지를 중복으로 서버에 요청하지않도록 수정했습니다.
    - 알려주신 mutateasync, 외부에서 onSuccess처리 둘 다 시도해봤는데 해결이 안되어서 기존의 서버에 바로 업로드하는 방식을 이미지값이 없거나 인풋이 수정된 곳에서만 api요청을 하도록 수정하였습니다.

### 📌 스크린샷 / 테스트결과 (선택)

---
- 비교하기 모달 연결
![비교하기](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/9d07a4bd-f903-439f-b468-9e7533daabc8)

- 이미지 인풋 api중복 요청하는 문제 수정
![이미지 인풋 수정](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/cf5b8be0-49fb-4d4d-9a2a-329cbbfa615b)

