### PR TITLE
Feat:유저 페이지 서버 사이드 렌더링 등

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -11,9 +11,11 @@ const instance = axios.create({
 
 instance.interceptors.request.use(
 	(config) => {
-		const token = getCookies()["accessToken"];
-		if (token) {
-			config.headers["Authorization"] = `Bearer ${token}`;
+		if (typeof document !== "undefined") {
+			const token = getCookies()["accessToken"];
+			if (token) {
+				config.headers["Authorization"] = `Bearer ${token}`;
+			}
 		}
 		return config;
 	},

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -27,8 +27,13 @@ export const patchUpdateMe = async ({
 	return response.data;
 };
 
-export const getUserDetail = async (userId: number): Promise<UserDetail> => {
-	const response = await instance.get<UserDetail>(`users/${userId}`);
+export const getUserDetail = async (
+	userId: number,
+	config = {},
+): Promise<UserDetail> => {
+	const response = await instance.get<UserDetail>(`users/${userId}`, {
+		...config,
+	});
 	return response.data;
 };
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -9,8 +9,8 @@ import {
 
 import instance from "./axiosInstance";
 
-export const getMe = async (): Promise<UserDetail> => {
-	const response = await instance.get<UserDetail>(`users/me`);
+export const getMe = async (config = {}): Promise<UserDetail> => {
+	const response = await instance.get<UserDetail>(`users/me`, { ...config });
 	return response.data;
 };
 

--- a/src/components/user/FilteredProductList.tsx
+++ b/src/components/user/FilteredProductList.tsx
@@ -17,7 +17,7 @@ export default function FilteredProductList({ user }: { user: UserDetail }) {
 
 	const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
 		useInfiniteQuery({
-			queryKey: ["products", user?.id, currentFilter.type],
+			queryKey: ["products", user.id, currentFilter.type],
 			queryFn: ({ pageParam }) =>
 				getUserProducts(user.id, currentFilter.type, pageParam),
 			initialPageParam: 0,

--- a/src/components/user/FilteredProductList.tsx
+++ b/src/components/user/FilteredProductList.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getUserProducts } from "@/apis/user";
 import { UserDetail } from "@/types/user";
@@ -24,6 +24,10 @@ export default function FilteredProductList({ user }: { user: UserDetail }) {
 			getNextPageParam: (lastPage) => lastPage.nextCursor,
 			staleTime: 60 * 1000 * 2,
 		});
+
+	useEffect(() => {
+		setFilter(productsFilter[0]);
+	}, [user]);
 
 	return (
 		<section className="flex flex-col gap-[3rem]">

--- a/src/components/user/FilteredProductList.tsx
+++ b/src/components/user/FilteredProductList.tsx
@@ -1,142 +1,48 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
+import { useState } from "react";
 
 import { getUserProducts } from "@/apis/user";
-import Dropdown from "@/components/common/dropdown/Dropdown";
-import ProductCard from "@/components/common/productcard/ProductCard";
-import { BREAK_POINT } from "@/constants/breakPoint";
-import { useIntersect } from "@/hooks/common/useIntersect";
-import useWindowWidth from "@/hooks/common/useWindowWidth";
-import { UserProductType } from "@/types/product";
 import { UserDetail } from "@/types/user";
-import cn from "@/utils/cn";
 
-const productsFilter: ProductFilter[] = [
-	{
-		id: 0,
-		name: "리뷰 남긴 상품",
-		type: "reviewed-products",
-	},
-	{
-		id: 1,
-		name: "등록한 상품",
-		type: "created-products",
-	},
-	{
-		id: 2,
-		name: "찜한 상품",
-		type: "favorite-products",
-	},
-];
-
-type ProductFilter = {
-	id: number;
-	name: string;
-	type: UserProductType;
-};
+import FilteredProductListFilter, {
+	ProductFilter,
+	productsFilter,
+} from "./FilteredProductListFilter";
+import FilteredProductListProducts from "./FilteredProductListProducts";
+import Loading from "./Loading";
+import NoProducts from "./NoProducts";
 
 export default function FilteredProductList({ user }: { user: UserDetail }) {
 	const [currentFilter, setFilter] = useState<ProductFilter>(productsFilter[0]);
-	const [isLarge, setIsLarge] = useState(false);
-	const currentWidth = useWindowWidth();
 
-	const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
-		queryKey: ["products", user?.id, currentFilter.type],
-		queryFn: ({ pageParam }) =>
-			getUserProducts(user.id, currentFilter.type, pageParam),
-		initialPageParam: 0,
-		getNextPageParam: (lastPage) => lastPage.nextCursor,
-		staleTime: 60 * 1000 * 2,
-	});
-
-	const intersectRef = useIntersect(
-		async (entry, observer) => {
-			observer.unobserve(entry.target);
-			if (hasNextPage && !isFetching) {
-				fetchNextPage();
-			}
-		},
-		{ rootMargin: "200px" },
-	);
-
-	const handleSelectFilter = (filter: ProductFilter) => {
-		setFilter(filter);
-	};
-
-	const renderProducts = () => {
-		return !data?.pages[0].list.length ? (
-			<div className="p-[1rem] text-center md:p-[2rem] lg:p-[3rem]">
-				<span className="text-[1.7rem] font-semibold text-gray-200 lg:text-[1.9rem]">
-					상품이 없습니다.
-				</span>
-			</div>
-		) : (
-			<div className="grid grid-cols-2 gap-[1.5rem] lg:grid-cols-3 lg:gap-[2rem]">
-				{data?.pages.map((group, i) => (
-					<Fragment key={i}>
-						{group.list.map((product, idx, arr) => {
-							const isLastItem = idx === arr.length - 1;
-							return (
-								<Link key={product.id} href={`/productdetail/${product.id}`}>
-									<ProductCard
-										ref={isLastItem ? intersectRef : null}
-										imageData={product.image}
-										likeCount={product.favoriteCount}
-										productName={product.name}
-										rate={product.rating}
-										reviewCount={product.reviewCount}
-									/>
-								</Link>
-							);
-						})}
-					</Fragment>
-				))}
-			</div>
-		);
-	};
-
-	useEffect(() => {
-		setIsLarge(currentWidth >= BREAK_POINT.lg);
-	}, [currentWidth]);
+	const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
+		useInfiniteQuery({
+			queryKey: ["products", user?.id, currentFilter.type],
+			queryFn: ({ pageParam }) =>
+				getUserProducts(user.id, currentFilter.type, pageParam),
+			initialPageParam: 0,
+			getNextPageParam: (lastPage) => lastPage.nextCursor,
+			staleTime: 60 * 1000 * 2,
+		});
 
 	return (
 		<section className="flex flex-col gap-[3rem]">
 			<h2 className="sr-only">{currentFilter.name}</h2>
-			{isLarge ? (
-				<ul className="flex gap-[4rem]">
-					{productsFilter.map((filter) => (
-						<li key={filter.id}>
-							<button onClick={() => handleSelectFilter(filter)}>
-								<span
-									className={cn(
-										"text-[2rem] text-gray-200",
-										filter.id === currentFilter.id &&
-											"font-semibold text-white",
-									)}
-								>
-									{filter.name}
-								</span>
-							</button>
-						</li>
-					))}
-				</ul>
+			<FilteredProductListFilter
+				currentFilter={currentFilter}
+				setFilter={setFilter}
+			/>
+			{isLoading && <Loading />}
+			{!isLoading && !data?.pages[0].list.length ? (
+				<NoProducts />
 			) : (
-				<Dropdown
-					items={productsFilter}
-					defaultItem={productsFilter[0]}
-					onSelect={handleSelectFilter}
-					className="w-[15rem]"
-				>
-					<Dropdown.Button
-						variant={"small"}
-						className="text-[1.8rem] font-semibold text-white lg:text-[2rem]"
-					/>
-					<Dropdown.List />
-				</Dropdown>
+				<FilteredProductListProducts
+					data={data}
+					fetchNextPage={fetchNextPage}
+					hasNextPage={hasNextPage}
+					isFetching={isFetching}
+				/>
 			)}
-
-			{renderProducts()}
 		</section>
 	);
 }

--- a/src/components/user/FilteredProductList.tsx
+++ b/src/components/user/FilteredProductList.tsx
@@ -33,7 +33,7 @@ export default function FilteredProductList({ user }: { user: UserDetail }) {
 				setFilter={setFilter}
 			/>
 			{isLoading && <Loading />}
-			{!isLoading && !data?.pages[0].list.length ? (
+			{!isLoading && !data?.pages?.[0].list?.length ? (
 				<NoProducts />
 			) : (
 				<FilteredProductListProducts

--- a/src/components/user/FilteredProductListFilter.tsx
+++ b/src/components/user/FilteredProductListFilter.tsx
@@ -1,0 +1,84 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+import Dropdown from "@/components/common/dropdown/Dropdown";
+import { BREAK_POINT } from "@/constants/breakPoint";
+import useWindowWidth from "@/hooks/common/useWindowWidth";
+import { UserProductType } from "@/types/product";
+import cn from "@/utils/cn";
+
+export const productsFilter: ProductFilter[] = [
+	{
+		id: 0,
+		name: "리뷰 남긴 상품",
+		type: "reviewed-products",
+	},
+	{
+		id: 1,
+		name: "등록한 상품",
+		type: "created-products",
+	},
+	{
+		id: 2,
+		name: "찜한 상품",
+		type: "favorite-products",
+	},
+];
+
+export type ProductFilter = {
+	id: number;
+	name: string;
+	type: UserProductType;
+};
+
+type Props = {
+	currentFilter: ProductFilter;
+	setFilter: Dispatch<SetStateAction<ProductFilter>>;
+};
+
+export default function FilteredProductListFilter({
+	currentFilter,
+	setFilter,
+}: Props) {
+	const [isLarge, setIsLarge] = useState(false);
+	const currentWidth = useWindowWidth();
+
+	const handleSelectFilter = (filter: ProductFilter) => {
+		setFilter(filter);
+	};
+
+	useEffect(() => {
+		setIsLarge(currentWidth >= BREAK_POINT.lg);
+	}, [currentWidth]);
+
+	return isLarge ? (
+		<ul className="flex gap-[4rem]">
+			{productsFilter.map((filter) => (
+				<li key={filter.id}>
+					<button onClick={() => handleSelectFilter(filter)}>
+						<span
+							className={cn(
+								"text-[2rem] text-gray-200",
+								filter.id === currentFilter.id && "font-semibold text-white",
+							)}
+						>
+							{filter.name}
+						</span>
+					</button>
+				</li>
+			))}
+		</ul>
+	) : (
+		<Dropdown
+			items={productsFilter}
+			defaultItem={productsFilter[0]}
+			onSelect={handleSelectFilter}
+			className="w-[15rem]"
+		>
+			<Dropdown.Button
+				variant={"small"}
+				className="text-[1.8rem] font-semibold text-white lg:text-[2rem]"
+			/>
+			<Dropdown.List />
+		</Dropdown>
+	);
+}

--- a/src/components/user/FilteredProductListProducts.tsx
+++ b/src/components/user/FilteredProductListProducts.tsx
@@ -1,0 +1,63 @@
+import {
+	FetchNextPageOptions,
+	InfiniteData,
+	InfiniteQueryObserverResult,
+} from "@tanstack/react-query";
+import Link from "next/link";
+import { Fragment } from "react";
+
+import ProductCard from "@/components/common/productcard/ProductCard";
+import { useIntersect } from "@/hooks/common/useIntersect";
+import { ProductsResponse } from "@/types/product";
+
+type Props = {
+	data: InfiniteData<ProductsResponse, unknown> | undefined;
+	fetchNextPage: (
+		options?: FetchNextPageOptions | undefined,
+	) => Promise<
+		InfiniteQueryObserverResult<InfiniteData<ProductsResponse, unknown>, Error>
+	>;
+	hasNextPage: boolean;
+	isFetching: boolean;
+};
+
+export default function FilteredProductListProducts({
+	data,
+	fetchNextPage,
+	hasNextPage,
+	isFetching,
+}: Props) {
+	const intersectRef = useIntersect(
+		async (entry, observer) => {
+			observer.unobserve(entry.target);
+			if (hasNextPage && !isFetching) {
+				fetchNextPage();
+			}
+		},
+		{ rootMargin: "200px" },
+	);
+
+	return (
+		<div className="grid grid-cols-2 gap-[1.5rem] lg:grid-cols-3 lg:gap-[2rem]">
+			{data?.pages.map((group, i) => (
+				<Fragment key={i}>
+					{group.list.map((product, idx, arr) => {
+						const isLastItem = idx === arr.length - 1;
+						return (
+							<Link key={product.id} href={`/productdetail/${product.id}`}>
+								<ProductCard
+									ref={isLastItem ? intersectRef : null}
+									imageData={product.image}
+									likeCount={product.favoriteCount}
+									productName={product.name}
+									rate={product.rating}
+									reviewCount={product.reviewCount}
+								/>
+							</Link>
+						);
+					})}
+				</Fragment>
+			))}
+		</div>
+	);
+}

--- a/src/components/user/Loading.tsx
+++ b/src/components/user/Loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+	return (
+		<div className="p-[1rem] text-center md:p-[2rem] lg:p-[3rem]">
+			<span className="text-[1.7rem] font-semibold text-gray-200 lg:text-[1.9rem]">
+				로딩중입니다.
+			</span>
+		</div>
+	);
+}

--- a/src/components/user/NoProducts.tsx
+++ b/src/components/user/NoProducts.tsx
@@ -1,0 +1,9 @@
+export default function NoProducts() {
+	return (
+		<div className="p-[1rem] text-center md:p-[2rem] lg:p-[3rem]">
+			<span className="text-[1.7rem] font-semibold text-gray-200 lg:text-[1.9rem]">
+				상품이 없습니다.
+			</span>
+		</div>
+	);
+}

--- a/src/components/user/ProfileCard.tsx
+++ b/src/components/user/ProfileCard.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { useCallback } from "react";
 
 import { deleteFollow, postFollow } from "@/apis/follow";
@@ -6,6 +7,7 @@ import BasicButton from "@/components/common/button/BasicButton";
 import ProfileImage from "@/components/common/profileImage/ProfileImage";
 import { useModalActions } from "@/store/modal";
 import { UserDetail } from "@/types/user";
+import getCookies from "@/utils/getCookies";
 
 import FollowUsersModal from "./FollowUsersModal";
 import ProfileModifyModal from "./ProfileModifyModal";
@@ -25,6 +27,15 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["user", user.id] });
 		},
+		onError: (error) => {
+			if (isAxiosError(error)) {
+				openModal(
+					<div className="p-[1.5rem] text-center text-[1.8rem] text-gray-400 lg:text-[2rem]">
+						{error?.response?.data.message || "팔로우 실패했습니다."}
+					</div>,
+				);
+			}
+		},
 	});
 
 	const handleOpenProfileModifyModal = () => {
@@ -43,8 +54,17 @@ export default function ProfileCard({ user, isMine = true }: Props) {
 	};
 
 	const handleClickFollow = useCallback(() => {
+		const token = getCookies()["accessToken"];
+		if (!token) {
+			openModal(
+				<div className="p-[1.5rem] text-center text-[1.8rem] text-gray-400 lg:text-[2rem]">
+					로그인이 필요합니다.
+				</div>,
+			);
+		}
+
 		followMutation.mutate(user.id);
-	}, [followMutation, user.id]);
+	}, [followMutation, openModal, user.id]);
 
 	return (
 		<section className="_flex-col-center w-[33.5rem] gap-[3rem] rounded-[1.2rem] border border-black-border bg-black-bg px-[2rem] py-[3rem] md:w-[50.9rem] lg:w-[34rem]">

--- a/src/components/user/ProfilePageLayout.tsx
+++ b/src/components/user/ProfilePageLayout.tsx
@@ -16,9 +16,9 @@ export default function ProfilePageLayout({ user }: Props) {
 	const isMine = router.asPath.includes("mypage");
 
 	return (
-		<>
+		<div className="min-h-screen bg-[#1C1C22]">
 			<Header />
-			<main className="_flex-col-center gap-[6rem] bg-[#1C1C22] px-[2rem] py-[3rem] lg:flex-row lg:items-start lg:p-[6rem]">
+			<main className="_flex-col-center gap-[6rem] px-[2rem] py-[3rem] lg:flex-row lg:items-start lg:p-[6rem]">
 				<h1 className="sr-only">프로필 페이지</h1>
 				<ProfileCard user={user} isMine={isMine} />
 				<div className="flex w-[33.5rem] max-w-[94rem] grow flex-col gap-[6rem] md:w-[50.9rem]">
@@ -26,6 +26,6 @@ export default function ProfilePageLayout({ user }: Props) {
 					<FilteredProductList user={user} />
 				</div>
 			</main>
-		</>
+		</div>
 	);
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,24 @@
 import "@/styles/globals.css";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	HydrationBoundary,
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { AppProps } from "next/app";
-import React, { ReactNode, useState } from "react";
+import { ReactNode, useState } from "react";
 
 import ModalWrapper from "@/components/common/modal/ModalWrapper";
 import { useModalActions, useModalsStore } from "@/store/modal";
 
-function Providers({ children }: { children: ReactNode }) {
+function Providers({
+	children,
+	pageProps,
+}: {
+	children: ReactNode;
+	pageProps: any;
+}) {
 	const [queryClient] = useState(() => new QueryClient());
 	const modals = useModalsStore();
 	const { closeModal } = useModalActions();
@@ -16,17 +26,19 @@ function Providers({ children }: { children: ReactNode }) {
 	return (
 		<>
 			<QueryClientProvider client={queryClient}>
-				{modals.map((modal) => (
-					<ModalWrapper
-						id={modal.id}
-						key={modal.id}
-						onRemove={() => closeModal(modal.id)}
-						config={modal.config}
-					>
-						{modal.content}
-					</ModalWrapper>
-				))}
-				{children}
+				<HydrationBoundary state={pageProps.dehydratedState}>
+					{modals.map((modal) => (
+						<ModalWrapper
+							id={modal.id}
+							key={modal.id}
+							onRemove={() => closeModal(modal.id)}
+							config={modal.config}
+						>
+							{modal.content}
+						</ModalWrapper>
+					))}
+					{children}
+				</HydrationBoundary>
 				<ReactQueryDevtools initialIsOpen={false} />
 			</QueryClientProvider>
 		</>
@@ -36,7 +48,7 @@ function Providers({ children }: { children: ReactNode }) {
 export default function App({ Component, pageProps }: AppProps) {
 	return (
 		<>
-			<Providers>
+			<Providers pageProps={pageProps}>
 				<Component {...pageProps} />
 			</Providers>
 		</>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,10 +1,17 @@
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { dehydrate, QueryClient, useQuery } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { GetServerSidePropsContext } from "next";
+import { useEffect } from "react";
 
 import { getMe } from "@/apis/user";
+import Loading from "@/components/user/Loading";
 import ProfilePageLayout from "@/components/user/ProfilePageLayout";
+import { UserDetail } from "@/types/user";
 import getAccessTokenFromReq from "@/utils/getAccessTokenFromReq";
 
 export async function getServerSideProps({ req }: GetServerSidePropsContext) {
+	const queryClient = new QueryClient();
+
 	const accessToken = getAccessTokenFromReq(req);
 	if (!accessToken) {
 		return {
@@ -15,19 +22,41 @@ export async function getServerSideProps({ req }: GetServerSidePropsContext) {
 		};
 	}
 
-	const me = await getMe({
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-		},
+	await queryClient.prefetchQuery<UserDetail>({
+		queryKey: ["me"],
+		queryFn: () =>
+			getMe({
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			}),
+		staleTime: 60 * 1000,
 	});
 
 	return {
-		props: { me },
+		props: { dehydratedState: dehydrate(queryClient) },
 	};
 }
 
-export default function MyPage({
-	me,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function MyPage() {
+	const { data: me, error } = useQuery<UserDetail>({
+		queryKey: ["me"],
+		queryFn: getMe,
+		staleTime: 60 * 1000,
+		retry: 0,
+	});
+
+	useEffect(() => {
+		if (error && isAxiosError<{ message: string }>(error)) {
+			console.error("error", error);
+			alert(error.response?.data.message);
+			window.location.href = "/";
+		}
+	}, [error]);
+
+	if (!me) {
+		return <Loading />;
+	}
+
 	return <ProfilePageLayout user={me} />;
 }

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,17 +1,33 @@
-import { useQuery } from "@tanstack/react-query";
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 
 import { getMe } from "@/apis/user";
 import ProfilePageLayout from "@/components/user/ProfilePageLayout";
-import { UserDetail } from "@/types/user";
+import getAccessTokenFromReq from "@/utils/getAccessTokenFromReq";
 
-export default function MyPage() {
-	const { data: me } = useQuery<UserDetail>({
-		queryKey: ["me"],
-		queryFn: getMe,
+export async function getServerSideProps({ req }: GetServerSidePropsContext) {
+	const accessToken = getAccessTokenFromReq(req);
+	if (!accessToken) {
+		return {
+			redirect: {
+				destination: "/signin",
+				permanent: false,
+			},
+		};
+	}
+
+	const me = await getMe({
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+		},
 	});
 
-	if (!me) {
-		return <div>Loading...</div>;
-	}
+	return {
+		props: { me },
+	};
+}
+
+export default function MyPage({
+	me,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
 	return <ProfilePageLayout user={me} />;
 }

--- a/src/pages/user/[id].tsx
+++ b/src/pages/user/[id].tsx
@@ -1,5 +1,4 @@
 import {
-	GetServerSideProps,
 	GetServerSidePropsContext,
 	GetServerSidePropsResult,
 	InferGetServerSidePropsType,

--- a/src/pages/user/[id].tsx
+++ b/src/pages/user/[id].tsx
@@ -25,7 +25,12 @@ export async function getServerSideProps({
 
 	await queryClient.prefetchQuery<UserDetail>({
 		queryKey: ["user", userId],
-		queryFn: () => getUserDetail(userId),
+		queryFn: () =>
+			getUserDetail(userId, {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			}),
 		staleTime: 60 * 1000,
 	});
 

--- a/src/utils/getAccessTokenFromReq.ts
+++ b/src/utils/getAccessTokenFromReq.ts
@@ -1,0 +1,12 @@
+import { IncomingMessage } from "http";
+
+export default function getAccessTokenFromReq(req: IncomingMessage): string {
+	const cookies = req.headers.cookie || "";
+	return (
+		cookies
+			.split(";")
+			.map((cookie) => cookie.trim().split("="))
+			.filter(([name]) => name === "accessToken")
+			.map(([_, value]) => value)[0] || ""
+	);
+}


### PR DESCRIPTION
close #161 

### 📌 작업 사항

---

- [구현] user, mypage 서버 사이드 렌더링 -> 서버에서도 리액트 쿼리를 사용하도록 했습니다.
- [리팩터링] FilteredProductList 컴포넌트 분리
- [구현] 상품 갯수와 상관 없이 height 꽉 차도록
- [구현] FollowUsersModal 로딩 상태 추가 및 스크롤 바 얇게 스타일링
- [수정] 유저 변경 시에도 상품 필터 유지되는 현상
- [구현] 유저 팔로우 시 accessToken 확인 및 모달로 알림

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---

~하다보니 눈에 띄는 거 다 수정하게 됐네요.. 딱히 이슈는 없습니다.~
~팔로우 하면 새로운 데이터를 잘 가져오는 계정이 있고 아닌 계정이 있습니다.. 도저히 왜 그런지 모르겠네요 😢~
서버에서 엑세스 토큰을 포함해서 보내지 않아서 이런 일이 벌어졌던 거군요.. 😅 수정했습니다!
채연님 덕에 스크롤바 스타일링 아주 손쉽게 했습니다👍 감사합니다.

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
