### PR TITLE
feat: 상품 상세페이지 카카오톡 공유 기능 구현

### DIFF
--- a/src/components/productdetail/DetailCard.tsx
+++ b/src/components/productdetail/DetailCard.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 import Image from "next/image";
+import { useEffect } from "react";
 
 import { deleteFavorite, postFavorite } from "@/apis/products";
 import useCompareModal from "@/hooks/compare/useCompareModal";
@@ -122,8 +123,20 @@ export default function DetailCard({ productData, isMyProduct }: Props) {
 
 export function Share({ className }: ShareProps) {
 	const { openModal, closeModal } = useModalActions();
+
+	const shareUrl = typeof window !== "undefined" ? window.location.href : "";
+
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			if (!window.Kakao.isInitialized()) {
+				window.Kakao.init("2fad6374928f2fdae3ad76e79d72417d");
+			}
+			//env파일 key로 수정 예정
+		}
+	}, []);
+
 	const handleCopyClipBoard = () => {
-		navigator.clipboard.writeText(window.location.href);
+		navigator.clipboard.writeText(shareUrl);
 		const modalId = openModal(
 			<ReviewAlertModal
 				closeModal={() => closeModal(modalId)}
@@ -136,9 +149,18 @@ export function Share({ className }: ShareProps) {
 		);
 	};
 
+	const handleCopyKakao = () => {
+		window.Kakao.Share.sendScrap({
+			requestUrl: shareUrl,
+		});
+	};
+
 	return (
 		<div className={cn("flex gap-[1rem]", className)}>
-			<button className="bg-black-bg flex size-[2.4rem] items-center justify-center rounded-[0.6rem] lg:size-[2.8rem]">
+			<button
+				className="flex size-[2.4rem] items-center justify-center rounded-[0.6rem] bg-black-bg lg:size-[2.8rem]"
+				onClick={handleCopyKakao}
+			>
 				<div className="relative size-[1.4rem] lg:size-[1.8rem]">
 					<Image
 						src="/icons/kakaotalk.svg"
@@ -148,9 +170,8 @@ export function Share({ className }: ShareProps) {
 					/>
 				</div>
 			</button>
-			{/**TODO: 카카오공유는 배포이후 추가 가능*/}
 			<button
-				className="bg-black-bg flex size-[2.4rem] items-center justify-center rounded-[0.6rem] lg:size-[2.8rem]"
+				className="flex size-[2.4rem] items-center justify-center rounded-[0.6rem] bg-black-bg lg:size-[2.8rem]"
 				onClick={handleCopyClipBoard}
 			>
 				<div className="relative size-[1.4rem] lg:size-[1.8rem]">

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,9 +1,23 @@
 import { Head, Html, Main, NextScript } from "next/document";
+import Script from "next/script";
+
+declare global {
+	interface Window {
+		Kakao: any;
+	}
+}
 
 export default function Document() {
 	return (
 		<Html lang="ko">
-			<Head />
+			<Head>
+				<Script
+					src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.1/kakao.min.js"
+					integrity="sha384-kDljxUXHaJ9xAb2AzRd59KxjrFjzHa5TAoFQ6GbYTCAG0bjM55XohjjDT7tDDC01"
+					crossOrigin="anonymous"
+					strategy="afterInteractive"
+				></Script>
+			</Head>
 			<body>
 				<Main />
 				<div id="modal-root"></div>


### PR DESCRIPTION
Close #167 
### 📌 작업 사항

---
- [구현] 카카오톡 공유
    - 자바스크립트key를 그대로 넣어서 사용하였는데, Oauth 기능구현된 이후에 env파일에서 가져오도록 수정할 예정입니다.

### 📌 스크린샷 / 테스트결과 (선택)

---
![카톡공유](https://github.com/4-2-mogazoa/mogazoa/assets/148832721/539688a6-f04f-4e95-911d-9509d405a328)
