### PR TITLE
Feat: 비교하기 페이지 기능 오류 수정 사항들

### DIFF
--- a/src/components/compare/ChangeProductModal.tsx
+++ b/src/components/compare/ChangeProductModal.tsx
@@ -1,9 +1,10 @@
 import clsx from "clsx";
-import { forwardRef, useState } from "react";
+import { useState } from "react";
 
 import useCompareStore from "@/store/compare";
 import { useModalActions } from "@/store/modal";
 import { CompareStatePosition, StoredProductInfo } from "@/types/compare";
+import { moveModalText } from "@/utils/modalText";
 
 import BasicButton from "../common/button/BasicButton";
 import MovingPageModal from "../common/modal/MovingPageModal";
@@ -70,7 +71,7 @@ export default function ChangeProductModal({
 
 		const modalId = openModal(
 			<MovingPageModal
-				description="비교 상품이 교체되었습니다. 바로 확인해 보시겠어요?"
+				description={moveModalText.changeProduct}
 				closeModal={() => closeMovePageModal(modalId)}
 				url="/compare"
 			/>,

--- a/src/components/compare/CompareForm.tsx
+++ b/src/components/compare/CompareForm.tsx
@@ -1,11 +1,16 @@
-import { FormEvent, useState } from "react";
+import { FormEvent } from "react";
 
+import useSigninModal from "@/hooks/common/useSigninModal";
 import useCompareQueries from "@/hooks/compare/useCompareQueries";
 
 import BasicButton from "../common/button/BasicButton";
 import CompareInput from "./CompareInput";
 
-export default function CompareForm() {
+type Props = {
+	openSigninModal?: () => void;
+};
+
+export default function CompareForm({ openSigninModal }: Props) {
 	const {
 		state: {
 			numberOfProducts,
@@ -16,7 +21,12 @@ export default function CompareForm() {
 
 	const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		// TODO: 모달 띄우기 ? - 어차피 인풋에 에러메시지를 보여주니까, 필요없을까?
+
+		if (openSigninModal) {
+			openSigninModal();
+			return;
+		}
+
 		if (numberOfProducts !== 2) return;
 
 		refetchAll();

--- a/src/components/compare/CompareInput.tsx
+++ b/src/components/compare/CompareInput.tsx
@@ -1,10 +1,11 @@
 import useCompareInputState from "@/hooks/compare/useCompareInputState";
+import { CompareStatePosition } from "@/types/compare";
 
 import ProductNameTag from "../common/productNameTag/ProductNameTag";
 import CompareDropdown from "./CompareDropdown";
 
 type Props = {
-	position: "firstProduct" | "secondProduct";
+	position: CompareStatePosition;
 	label: "상품 1" | "상품 2";
 	product?: { id: number; name: string } | null;
 	tagColor: "green" | "pink";

--- a/src/components/compare/Loading.tsx
+++ b/src/components/compare/Loading.tsx
@@ -13,7 +13,9 @@ export default function Loading() {
 					className="absolute left-0 top-0"
 				/>
 			</div>
-			<p className="text-[1.8rem] text-gray-200 lg:text-[2rem]">Loading...</p>
+			<p className="text-[1.8rem] text-gray-200 lg:text-[2rem]">
+				원하는 상품을 비교해 보세요.
+			</p>
 		</div>
 	);
 }

--- a/src/hooks/common/useSigninModal.tsx
+++ b/src/hooks/common/useSigninModal.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useEffect } from "react";
+
+import { getMe } from "@/apis/user";
+import MovingPageModal from "@/components/common/modal/MovingPageModal";
+import { useModalActions } from "@/store/modal";
+import { moveModalText } from "@/utils/modalText";
+
+export default function IsneededSigninModal(accessToken: string) {
+	const { openModal, closeModal } = useModalActions();
+
+	const { data: myData, isFetching } = useQuery({
+		queryKey: ["me"],
+		queryFn: () => getMe(),
+		retry: 0,
+	});
+
+	const openSigninModal = () => {
+		const modalId = openModal(
+			<MovingPageModal
+				description={moveModalText.signin}
+				closeModal={() => closeModal(modalId)}
+				url="/signin"
+			/>,
+		);
+	};
+
+	if (!isFetching && !myData && !accessToken) {
+		return openSigninModal;
+	}
+}

--- a/src/hooks/common/useSigninModal.tsx
+++ b/src/hooks/common/useSigninModal.tsx
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import { useEffect } from "react";
 
 import { getMe } from "@/apis/user";
 import MovingPageModal from "@/components/common/modal/MovingPageModal";
 import { useModalActions } from "@/store/modal";
 import { moveModalText } from "@/utils/modalText";
 
-export default function IsneededSigninModal(accessToken: string) {
+export default function OpenSigninModal(accessToken: string) {
 	const { openModal, closeModal } = useModalActions();
 
 	const { data: myData, isFetching } = useQuery({

--- a/src/hooks/compare/useCompareInputState.ts
+++ b/src/hooks/compare/useCompareInputState.ts
@@ -2,13 +2,12 @@ import { ChangeEvent, KeyboardEvent, useState } from "react";
 
 import { getProducts } from "@/apis/products";
 import useCompareStore from "@/store/compare";
+import { CompareStatePosition } from "@/types/compare";
 import { ProductsResponse } from "@/types/product";
 
 import useOutsideClick from "../common/useOutsideClick";
 
-export default function useCompareInputState(
-	position: "firstProduct" | "secondProduct",
-) {
+export default function useCompareInputState(position: CompareStatePosition) {
 	const { products, addProduct, deleteProduct } = useCompareStore();
 
 	const [keyword, setKeyword] = useState("");

--- a/src/hooks/compare/useCompareModal.tsx
+++ b/src/hooks/compare/useCompareModal.tsx
@@ -6,6 +6,7 @@ import useCompareStore from "@/store/compare";
 import { useModalActions } from "@/store/modal";
 import { CompareStatePosition } from "@/types/compare";
 import { ProductDetail } from "@/types/product";
+import { moveModalText } from "@/utils/modalText";
 
 type Return = {
 	compareButtonText: string;
@@ -40,7 +41,7 @@ export default function useCompareModal(
 			handleCompareButtonClick: () => {
 				const modalId = openModal(
 					<MovingPageModal
-						description="로그인이 필요한 서비스입니다. 로그인하시겠습니까?"
+						description={moveModalText.signin}
 						closeModal={() => closeModal(modalId)}
 						url="/signin"
 					/>,
@@ -82,7 +83,7 @@ export default function useCompareModal(
 
 					const modalId = openModal(
 						<MovingPageModal
-							description="상품이 담겼습니다. 바로 확인 해보시겠습니까?"
+							description={moveModalText.comparePage}
 							closeModal={() => closeModal(modalId)}
 							url="/compare"
 						/>,

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -1,19 +1,41 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useEffect } from "react";
+
 import Header from "@/components/common/menu/Header";
 import CompareForm from "@/components/compare/CompareForm";
 import Loading from "@/components/compare/Loading";
 import Result from "@/components/compare/Result";
+import useSigninModal from "@/hooks/common/useSigninModal";
 import useCompareQueries from "@/hooks/compare/useCompareQueries";
 
-export default function Index() {
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+	const accessToken = req.cookies.accessToken || "";
+
+	return {
+		props: {
+			accessToken,
+		},
+	};
+};
+
+export default function Index({
+	accessToken,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
 	const {
 		products: { firstProduct, secondProduct },
 	} = useCompareQueries();
+
+	const openSigninModal = useSigninModal(accessToken);
+
+	useEffect(() => {
+		openSigninModal && openSigninModal();
+	}, [openSigninModal]);
 
 	return (
 		<div className="h-full min-h-screen bg-[#1c1c22]">
 			<Header />
 			<div className="_flex-col-center mx-8 gap-24 pb-16 pt-12 md:mx-12 md:max-w-[94rem] md:pb-40 md:pt-16 lg:mx-auto lg:w-[94rem] lg:gap-32 lg:pt-24">
-				<CompareForm />
+				<CompareForm openSigninModal={openSigninModal} />
 				<div>
 					{firstProduct && secondProduct ? (
 						<Result firstProduct={firstProduct} secondProduct={secondProduct} />

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/common/menu/Header";
 import CompareForm from "@/components/compare/CompareForm";
 import Loading from "@/components/compare/Loading";
 import Result from "@/components/compare/Result";
-import useSigninModal from "@/hooks/common/useSigninModal";
+import OpenSigninModal from "@/hooks/common/useSigninModal";
 import useCompareQueries from "@/hooks/compare/useCompareQueries";
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
@@ -25,7 +25,7 @@ export default function Index({
 		products: { firstProduct, secondProduct },
 	} = useCompareQueries();
 
-	const openSigninModal = useSigninModal(accessToken);
+	const openSigninModal = OpenSigninModal(accessToken);
 
 	useEffect(() => {
 		openSigninModal && openSigninModal();

--- a/src/store/compare.ts
+++ b/src/store/compare.ts
@@ -1,15 +1,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-type ProductInfo = { id: number; name: string };
-
-type Position = "firstProduct" | "secondProduct";
+import { CompareStatePosition, StoredProductInfo } from "@/types/compare";
 
 type State = {
 	numberOfProducts: number;
 	products: {
-		firstProduct: ProductInfo | null;
-		secondProduct: ProductInfo | null;
+		firstProduct: StoredProductInfo | null;
+		secondProduct: StoredProductInfo | null;
 	};
 };
 
@@ -18,11 +16,14 @@ type Action = {
 	isAlreadyStoredProduct: (id: number) => boolean;
 	getCurrentProductPosition: (id: number) => string | undefined;
 	addProduct: (
-		newProduct: ProductInfo,
-		position?: Position,
+		newProduct: StoredProductInfo,
+		position?: CompareStatePosition,
 	) => string | undefined;
-	deleteProduct: (position: Position) => void;
-	changeProduct: (newProduct: ProductInfo, position: Position) => void;
+	deleteProduct: (position: CompareStatePosition) => void;
+	changeProduct: (
+		newProduct: StoredProductInfo,
+		position: CompareStatePosition,
+	) => void;
 	clearProducts: () => void;
 };
 

--- a/src/utils/modalText.ts
+++ b/src/utils/modalText.ts
@@ -1,4 +1,4 @@
-const moveModalText = {
+export const moveModalText = {
 	signin: "로그인이 필요한 서비스입니다. 로그인하시겠습니까?",
 	comparePage: "상품이 담겼습니다. 바로 확인 해보시겠습니까?",
 	changeProduct: "비교 상품이 교체되었습니다. 바로 확인해 보시겠어요?",


### PR DESCRIPTION
### 📌 작업 사항

---

- 페이지 진입 시 & 비교하기 버튼 누를 때, 로그인 여부 확인하는 기능 추가
- 비교하기 페이지에서 사용하는 타입 정리 & 모달 텍스트 constant에 별도로 분리한 것 사용
- 비교하기 드롭다운 리스트 추가로 불러올 때, useThrottle 함수를 사용하여 과도한 refetching으로 인한 오류 방지

### 📌 이슈 (에러, 막혔던 부분, 그외 궁금한것 등등)

---

### 📌 사용 방법 (선택)

---

### 📌 스크린샷 / 테스트결과 (선택)

---
